### PR TITLE
nfs4: verify seqid in OPEN_CONFIRM as per RFC

### DIFF
--- a/core/src/main/java/org/dcache/nfs/v4/NFS4Client.java
+++ b/core/src/main/java/org/dcache/nfs/v4/NFS4Client.java
@@ -43,6 +43,7 @@ package org.dcache.nfs.v4;
 import org.dcache.nfs.ChimeraNFSException;
 import org.dcache.nfs.nfsstat;
 import org.dcache.nfs.v4.xdr.stateid4;
+import org.dcache.nfs.v4.xdr.uint32_t;
 import org.dcache.utils.Opaque;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -293,13 +294,13 @@ public class NFS4Client {
         return _sessionSequence;
     }
 
-    public NFS4State createState() throws ChimeraNFSException {
+    public NFS4State createState(uint32_t openSeqid) throws ChimeraNFSException {
         if (_clientStates.size() >= MAX_OPEN_STATES) {
             throw new ChimeraNFSException(nfsstat.NFSERR_RESOURCE,
                     "Too many states.");
         }
 
-        NFS4State state = new NFS4State(_clientId, _openStateId);
+        NFS4State state = new NFS4State(_clientId, _openStateId, openSeqid);
         _openStateId++;
         _clientStates.put(state.stateid(), state);
         return state;

--- a/core/src/main/java/org/dcache/nfs/v4/NFS4State.java
+++ b/core/src/main/java/org/dcache/nfs/v4/NFS4State.java
@@ -23,6 +23,7 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import org.dcache.nfs.v4.xdr.stateid4;
+import org.dcache.nfs.v4.xdr.uint32_t;
 import org.dcache.utils.Bytes;
 
 public class NFS4State {
@@ -46,6 +47,7 @@ public class NFS4State {
     private final stateid4 _stateid;
     private boolean _isConfimed = false;
     private boolean _disposed = false;
+    private final uint32_t _openSeqid;
 
     private final List<StateDisposeListener> _disposeListeners;
 
@@ -54,13 +56,14 @@ public class NFS4State {
      */
     private static final SecureRandom RANDOM = new SecureRandom();
 
-    public NFS4State(stateid4 stateid) {
+    public NFS4State(stateid4 stateid, uint32_t openSeqid) {
         _stateid = stateid;
         _disposeListeners = new ArrayList<>();
+        _openSeqid = openSeqid;
     }
 
-    public NFS4State(long clientid, int seqid) {
-        this( new stateid4(generateState(clientid), seqid));
+    public NFS4State(long clientid, int seqid, uint32_t openSeqid) {
+        this( new stateid4(generateState(clientid), seqid), openSeqid);
     }
 
     private static byte[] generateState(long clientid) {
@@ -82,6 +85,13 @@ public class NFS4State {
     
     public boolean isConfimed() {
     	return _isConfimed;
+    }
+
+    /**
+     * Returns the seqid value the client sent us in their OPEN call.
+     */
+    public uint32_t getOpenSeqid() {
+        return _openSeqid;
     }
 
     /**

--- a/core/src/main/java/org/dcache/nfs/v4/OperationOPEN.java
+++ b/core/src/main/java/org/dcache/nfs/v4/OperationOPEN.java
@@ -241,7 +241,7 @@ public class OperationOPEN extends AbstractNFSv4Operation {
                         | nfs4_prot.OPEN4_RESULT_CONFIRM);                
             }
 
-            NFS4State nfs4state = client.createState();
+            NFS4State nfs4state = client.createState(_args.opopen.seqid.value);
             res.resok4.stateid = nfs4state.stateid();
 
             _log.debug("New stateID: {}", nfs4state.stateid());

--- a/core/src/main/java/org/dcache/nfs/v4/OperationOPEN_CONFIRM.java
+++ b/core/src/main/java/org/dcache/nfs/v4/OperationOPEN_CONFIRM.java
@@ -66,7 +66,7 @@ public class OperationOPEN_CONFIRM extends AbstractNFSv4Operation {
         }
 
         NFS4State state = client.state(stateid);
-        if (state.stateid().seqid.value != _args.opopen_confirm.seqid.value.value) {
+        if (state.getOpenSeqid().value + 1 != _args.opopen_confirm.seqid.value.value) {
             throw new ChimeraNFSException(nfsstat.NFSERR_BAD_SEQID, "bad seqid.");
         }
 

--- a/core/src/test/java/org/dcache/nfs/v4/NFS4ClientTest.java
+++ b/core/src/test/java/org/dcache/nfs/v4/NFS4ClientTest.java
@@ -27,6 +27,7 @@ import org.dcache.nfs.v4.client.CloseStub;
 import org.dcache.nfs.v4.xdr.nfs_argop4;
 import org.dcache.nfs.v4.xdr.nfs_opnum4;
 import org.dcache.nfs.v4.xdr.nfs_resop4;
+import org.dcache.nfs.v4.xdr.uint32_t;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -54,7 +55,7 @@ public class NFS4ClientTest {
         nfs_resop4 result;
 
         NFSv41Session session = nfsClient.createSession(1, 2);
-        NFS4State state = nfsClient.createState();
+        NFS4State state = nfsClient.createState(new uint32_t(0));
 
         nfs_argop4 close_args = CloseStub.generateRequest(state.stateid());
         OperationCLOSE CLOSE = new OperationCLOSE(close_args);
@@ -78,7 +79,7 @@ public class NFS4ClientTest {
         CompoundContext context;
         nfs_resop4 result;
 
-        NFS4State state = nfsClient.createState();
+        NFS4State state = nfsClient.createState(new uint32_t(0));
 
         nfs_argop4 close_args = CloseStub.generateRequest(state.stateid());
         OperationCLOSE CLOSE = new OperationCLOSE(close_args);
@@ -102,7 +103,7 @@ public class NFS4ClientTest {
 
     @Test
     public void testAttacheDetachState() throws ChimeraNFSException {
-        NFS4State state = new NFS4State(0, 0);
+        NFS4State state = new NFS4State(0, 0, new uint32_t(0));
 
         nfsClient.attachState(state);
         assertTrue(nfsClient.hasState());
@@ -113,7 +114,7 @@ public class NFS4ClientTest {
 
     @Test
     public void testCreateState() throws ChimeraNFSException {
-        NFS4State state = nfsClient.createState();
+        NFS4State state = nfsClient.createState(new uint32_t(0));
         assertTrue(nfsClient.hasState());
     }
 

--- a/core/src/test/java/org/dcache/nfs/v4/NFSv4StateHandlerTest.java
+++ b/core/src/test/java/org/dcache/nfs/v4/NFSv4StateHandlerTest.java
@@ -20,6 +20,7 @@
 package org.dcache.nfs.v4;
 
 import org.dcache.nfs.v4.xdr.stateid4;
+import org.dcache.nfs.v4.xdr.uint32_t;
 import org.dcache.nfs.v4.xdr.verifier4;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,13 +44,13 @@ public class NFSv4StateHandlerTest {
 
     @Test
     public void testGetByStateId() throws Exception {
-        stateid4 state = _client.createState().stateid();
+        stateid4 state = _client.createState(new uint32_t(0)).stateid();
         _stateHandler.getClientIdByStateId(state);
     }
 
     @Test
     public void testGetByVerifier() throws Exception {
-        stateid4 state = _client.createState().stateid();
+        stateid4 state = _client.createState(new uint32_t(0)).stateid();
         assertEquals(_client, _stateHandler.getClientByVerifier(_client.verifier()));
     }
 
@@ -71,7 +72,7 @@ public class NFSv4StateHandlerTest {
 
     @Test
     public void testUpdateLeaseTime() throws Exception {
-        NFS4State state = _client.createState();
+        NFS4State state = _client.createState(new uint32_t(0));
         stateid4 stateid = state.stateid();
         state.confirm();
         _stateHandler.updateClientLeaseTime(stateid);
@@ -79,7 +80,7 @@ public class NFSv4StateHandlerTest {
 
     @Test(expected=ChimeraNFSException.class)
     public void testUpdateLeaseTimeNotConfirmed() throws Exception {
-        NFS4State state = _client.createState();
+        NFS4State state = _client.createState(new uint32_t(0));
         stateid4 stateid = state.stateid();
 
         _stateHandler.updateClientLeaseTime(stateid);
@@ -87,7 +88,7 @@ public class NFSv4StateHandlerTest {
 
     @Test(expected=ChimeraNFSException.class)
     public void testUpdateLeaseTimeNotExists() throws Exception {
-        stateid4 state = _client.createState().stateid();
+        stateid4 state = _client.createState(new uint32_t(0)).stateid();
         _stateHandler.updateClientLeaseTime(state);
     }
 }


### PR DESCRIPTION
I've run into a problem with jpnfs when serving the NFS 4.0 (not 4.1) protocol to a Linux client. When opening and reading a file twice, the first time works fine, the second time we see these kernel messages on RHEL5 (Linux 2.6.18):

```
NFS: v4 server returned a bad sequence-id error!
NFS: v4 server returned a bad sequence-id error!
NFS: v4 server returned a bad sequence-id error!
NFS: v4 server returned a bad sequence-id error!
```

Or on RHEL6 (Linux 2.6.32) (with -o vers=4 not v4.1):

```
NFS: v4 server returned a bad sequence-id error on an unconfirmed sequence ffff881933529080!
NFS: v4 server 127.0.0.1  returned a bad sequence-id error!
```

After retrying a few thousand times the client gives up with:

```
cat: /mnt/tmp/foo: Remote I/O error
```

Investigating with a packet sniffer I see this sequence of calls the first time the file is read:

```
client OPEN {seqid: 0}
server OPEN reply NFS4_OK {stateid: {seqid: 1, data=...}}
client OPEN_CONFIRM {seqid: 1, stateid: {seqid: 1, data=...}}
server OPEN_CONFIRM reply NFS4_OK {stateid: {seqid: 2, data=...}}
```

But then the second time the file is read:

```
client OPEN {seqid: 0}
server OPEN reply NFS4_OK {stateid: {seqid: 2, data=...}}
client OPEN_CONFIRM {seqid: 1, stateid: {seqid: 2, data=...}}
server OPEN_CONFIRM reply NFS4ERR_BAD_SEQID
```

Then the client goes on to retry a large number of times:

```
client OPEN {seqid: 0}
server OPEN reply NFS4_OK {stateid: {seqid: 3, data=...}}
client OPEN_CONFIRM {seqid: 1, stateid: {seqid: 3, data=...}}
server OPEN_CONFIRM reply NFS4ERR_BAD_SEQID
client OPEN {seqid: 0}
server OPEN reply NFS4_OK {stateid: {seqid: 4, data=...}}
client OPEN_CONFIRM {seqid: 1, stateid: {seqid: 4, data=...}}
server OPEN_CONFIRM reply NFS4ERR_BAD_SEQID
.... and so on until stateid.seqid reaches 0x4001.
```

Looking at [OperationOPEN_CONFIRM.java](https://github.com/dCache/jpnfs/blob/f7fdc97e98827b738907afd6171bb7b9956c96f6/core/src/main/java/org/dcache/nfs/v4/OperationOPEN_CONFIRM.java#L69) this is how seqid is verified:

``` java
        stateid4 stateid = _args.opopen_confirm.open_stateid;
        NFS4Client client = context.getStateHandler().getClientIdByStateId(stateid);
        ...
        NFS4State state = client.state(stateid);
        if (state.stateid().seqid.value != _args.opopen_confirm.seqid.value.value) {
            throw new ChimeraNFSException(nfsstat.NFSERR_BAD_SEQID, "bad seqid.");
        }
```

If I'm interpreting the code correctly the server is therefore checking _args.opopen_confirm.seqid against its remembered stateid.seqid (i.e. the stateid.seqid the server returned in the OPEN response, not the seqid the client sent in the OPEN request).

I checked RFC3530 and it says:

```
14.2.18.  Operation 20: OPEN_CONFIRM - Confirm Open

  SYNOPSIS

     (cfh), seqid, stateid-> stateid

   ARGUMENT

     struct OPEN_CONFIRM4args {
             /* CURRENT_FH: opened file */
             stateid4        open_stateid;
             seqid4          seqid;
     };
...

   DESCRIPTION

   This operation is used to confirm the sequence id usage for the first
   time that a open_owner is used by a client.  The stateid returned
   from the OPEN operation is used as the argument for this operation
   along with the next sequence id for the open_owner.  The sequence id
   passed to the OPEN_CONFIRM must be 1 (one) greater than the seqid
   passed to the OPEN operation from which the open_confirm value was
   obtained.  If the server receives an unexpected sequence id with
   respect to the original open, then the server assumes that the client
   will not confirm the original OPEN and all state associated with the
   original OPEN is released by the server.
```

If I understand the RFC correctly, when making an OPEN_CONFIRM call, the client should echo the stateid that was returned by the server in the OPEN response. It should additionally send opopen_confirm.seqid as one plus the value the client sent for opopen.seqid.

However it seems then that the jpnfs server is verifying opopen_confirm.seqid against the wrong value. In fact I couldn't find anywhere in the server code where the seqid the client sends in the OPEN call (opopen.seqid) is used at all.

Is this a bug or am I misunderstanding the RFC? We're currently working around it with this patch but I'm unsure if it is the correct solution.
