### PR TITLE
more elegant human readable size calculation for Stat

### DIFF
--- a/core/src/main/java/org/dcache/nfs/vfs/Stat.java
+++ b/core/src/main/java/org/dcache/nfs/vfs/Stat.java
@@ -276,12 +276,8 @@ public class Stat {
     private final static String[] SIZE_UNITS = {"", "K", "M", "G", "T", "P", "E", "Z", "Y"};
 
     public static String sizeToString(long bytes) {
-        double significantSize = bytes;
-        int orderOfMagnitude = 0;
-        while (significantSize >= 1024) {
-            orderOfMagnitude++;
-            significantSize = bytes / Math.pow(1024, orderOfMagnitude); //start with _size to minimize loss of precision
-        }
+        int orderOfMagnitude = (int)Math.floor(Math.log(bytes) / Math.log(1024));
+        double significantSize = (double)bytes / (1L << orderOfMagnitude*10);
         DecimalFormat sizeFormat = new DecimalFormat("#.#"); //not thread safe
         return sizeFormat.format(significantSize)+SIZE_UNITS[orderOfMagnitude];
     }


### PR DESCRIPTION
as suggested in https://github.com/radai-rosenblatt/jpnfs/commit/20402fc248ed412f4b0525fada7be9faed8c80ca#commitcomment-7695035 (+cast to double to avoid truncation)
