### PR TITLE
fix NPE after READDIR in nfs3, enable console logging in dev/debug

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -68,6 +68,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <!-- to get console logging during development/debug -->
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/core/src/test/java/org/dcache/nfs/v3/NfsServerV3READDIR_3Test.java
+++ b/core/src/test/java/org/dcache/nfs/v3/NfsServerV3READDIR_3Test.java
@@ -1,0 +1,117 @@
+package org.dcache.nfs.v3;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.dcache.nfs.ExportFile;
+import org.dcache.nfs.nfsstat;
+import org.dcache.nfs.v3.xdr.READDIR3args;
+import org.dcache.nfs.v3.xdr.READDIR3res;
+import org.dcache.nfs.vfs.DirectoryEntry;
+import org.dcache.nfs.vfs.FileHandle;
+import org.dcache.nfs.vfs.Inode;
+import org.dcache.nfs.vfs.Stat;
+import org.dcache.nfs.vfs.VirtualFileSystem;
+import org.dcache.testutils.NfsV3Ops;
+import org.dcache.testutils.RpcCallBuilder;
+import org.dcache.xdr.RpcCall;
+import org.dcache.xdr.XdrAble;
+import org.dcache.xdr.XdrEncodingStream;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class NfsServerV3READDIR_3Test {
+
+    private FileHandle dirHandle;
+    private Inode dirInode;
+    private Stat dirStat;
+    private VirtualFileSystem vfs;
+    private NfsServerV3 nfsServer;
+
+    @Before
+    public void setup() throws Exception {
+        dirHandle = new FileHandle(0, 1, 0, new byte[] { 0, 0, 0, 1 }); // the dir we want to read
+        dirInode = new Inode(dirHandle);
+        dirStat = new Stat(); // the stat marking it as a dir
+        //noinspection OctalInteger
+        dirStat.setMode(Stat.S_IFDIR | 0755);
+        dirStat.setMTime(System.currentTimeMillis());
+        vfs = Mockito.mock(VirtualFileSystem.class); // the vfs serving it
+        Mockito.when(vfs.getattr(Mockito.eq(dirInode))).thenReturn(dirStat);
+        ExportFile exportFile = new ExportFile(this.getClass().getResource("simpleExports")); // same package as us
+        nfsServer = new NfsServerV3(exportFile, vfs);
+    }
+
+    @Test
+    public void testReadDirWithNoResults() throws Exception {
+        // vfs will return an empty list from the vfs for dir (technically legal)
+        Mockito.when(vfs.list(Mockito.eq(new Inode(dirHandle)))).thenReturn(Collections.<DirectoryEntry> emptyList());
+
+        // set up and execute the call
+        RpcCall call = new RpcCallBuilder().from("1.2.3.4", "someHost.acme.com", 42).nfs3().noAuth().build();
+        READDIR3args args = NfsV3Ops.readDir(dirHandle);
+        READDIR3res result = nfsServer.NFSPROC3_READDIR_3(call, args);
+
+        Assert.assertEquals(nfsstat.NFS_OK, result.status);
+        Assert.assertNull(result.resok.reply.entries); //no entries
+        Assert.assertTrue(result.resok.reply.eof); //eof
+        assertXdrEncodable(result);
+    }
+
+    @Test
+    public void testReadDirWithTinyLimit() throws Exception {
+        // vfs will return only "." and ".." as contents, both leading to itself
+        List<DirectoryEntry> dirContents = new ArrayList<>();
+        dirContents.add(new DirectoryEntry(".", dirInode, dirStat));
+        dirContents.add(new DirectoryEntry("..", dirInode, dirStat));
+        Mockito.when(vfs.list(Mockito.eq(dirInode))).thenReturn(dirContents);
+
+        // set up and execute the 1st call - no cookie, but very tight size limit
+        RpcCall call = new RpcCallBuilder().from("1.2.3.4", "someHost.acme.com", 42).nfs3().noAuth().build();
+        READDIR3args args = NfsV3Ops.readDir(dirHandle, 10); //10 bytes - not enough for anything
+        READDIR3res result = nfsServer.NFSPROC3_READDIR_3(call, args);
+
+        Assert.assertEquals(nfsstat.NFSERR_TOOSMALL, result.status); //error response
+    }
+
+    @Test
+    public void testContinueReadingAfterEOF() throws Exception {
+
+        // vfs will return only "." and ".." as contents, both leading to itself
+        List<DirectoryEntry> dirContents = new ArrayList<>();
+        dirContents.add(new DirectoryEntry(".", dirInode, dirStat));
+        dirContents.add(new DirectoryEntry("..", dirInode, dirStat));
+        Mockito.when(vfs.list(Mockito.eq(dirInode))).thenReturn(dirContents);
+
+        // set up and execute the 1st call - no cookie, but very tight size limit
+        RpcCall call = new RpcCallBuilder().from("1.2.3.4", "someHost.acme.com", 42).nfs3().noAuth().build();
+        READDIR3args args = NfsV3Ops.readDir(dirHandle);
+        READDIR3res result = nfsServer.NFSPROC3_READDIR_3(call, args);
+
+        Assert.assertEquals(nfsstat.NFS_OK, result.status); //response ok
+        Assert.assertTrue(result.resok.reply.eof); //eof
+        assertXdrEncodable(result);
+
+        // client violates spec - attempts to read more
+        // using cookie on last (2nd) entry and returned verifier
+        long cookie = result.resok.reply.entries.nextentry.cookie.value.value;
+        byte[] cookieVerifier = result.resok.cookieverf.value;
+        args = NfsV3Ops.readDir(dirHandle, cookie, cookieVerifier);
+        result = nfsServer.NFSPROC3_READDIR_3(call, args);
+
+        Assert.assertEquals(nfsstat.NFSERR_BAD_COOKIE, result.status); //error response
+        assertXdrEncodable(result);
+    }
+
+    private void assertXdrEncodable (XdrAble xdrAble) {
+        try {
+            XdrEncodingStream outputStream = Mockito.mock(XdrEncodingStream.class);
+            xdrAble.xdrEncode(outputStream); // should not blow up
+        } catch (Exception e) {
+            throw new AssertionError("object does not survive xdr encoding", e);
+        }
+    }
+}

--- a/core/src/test/java/org/dcache/testutils/InetAddressBuilder.java
+++ b/core/src/test/java/org/dcache/testutils/InetAddressBuilder.java
@@ -1,0 +1,27 @@
+package org.dcache.testutils;
+
+import java.net.InetAddress;
+
+import org.mockito.Mockito;
+
+public class InetAddressBuilder {
+    private String ipAddress;
+    private String hostName;
+
+    public InetAddressBuilder ip(String ipAddress) {
+        this.ipAddress = ipAddress;
+        return this;
+    }
+
+    public InetAddressBuilder hostName(String hostName) {
+        this.hostName = hostName;
+        return this;
+    }
+
+    public InetAddress build() {
+        InetAddress address = Mockito.mock(InetAddress.class);
+        Mockito.when(address.getHostAddress()).thenReturn(ipAddress);
+        Mockito.when(address.getHostName()).thenReturn(hostName);
+        return address;
+    }
+}

--- a/core/src/test/java/org/dcache/testutils/NfsV3Ops.java
+++ b/core/src/test/java/org/dcache/testutils/NfsV3Ops.java
@@ -1,0 +1,35 @@
+package org.dcache.testutils;
+
+import org.dcache.nfs.v3.xdr.READDIR3args;
+import org.dcache.nfs.v3.xdr.cookie3;
+import org.dcache.nfs.v3.xdr.cookieverf3;
+import org.dcache.nfs.v3.xdr.count3;
+import org.dcache.nfs.v3.xdr.nfs3_prot;
+import org.dcache.nfs.v3.xdr.nfs_fh3;
+import org.dcache.nfs.v3.xdr.uint32;
+import org.dcache.nfs.v3.xdr.uint64;
+import org.dcache.nfs.vfs.FileHandle;
+
+public class NfsV3Ops {
+    public static READDIR3args readDir(FileHandle requestedDirHandle) {
+        return readDir(requestedDirHandle, 0, new byte[nfs3_prot.NFS3_COOKIEVERFSIZE], Integer.MAX_VALUE);
+    }
+
+    public static READDIR3args readDir(FileHandle requestedDirHandle, int maxResponseSize) {
+        return readDir(requestedDirHandle, 0, new byte[nfs3_prot.NFS3_COOKIEVERFSIZE], maxResponseSize);
+    }
+
+    public static READDIR3args readDir(FileHandle requestedDirHandle, long cookie, byte[] cookieVerifier) {
+        return readDir(requestedDirHandle, cookie, cookieVerifier, Integer.MAX_VALUE);
+    }
+
+    public static READDIR3args readDir(FileHandle requestedDirHandle, long cookie, byte[] cookieVerifier, int maxResponseBytes) {
+        READDIR3args args = new READDIR3args();
+        args.dir = new nfs_fh3();
+        args.dir.data = requestedDirHandle.bytes();
+        args.cookie = new cookie3(new uint64(cookie));
+        args.cookieverf = new cookieverf3(cookieVerifier);
+        args.count = new count3(new uint32(maxResponseBytes));
+        return args;
+    }
+}

--- a/core/src/test/java/org/dcache/testutils/RpcCallBuilder.java
+++ b/core/src/test/java/org/dcache/testutils/RpcCallBuilder.java
@@ -1,0 +1,44 @@
+package org.dcache.testutils;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+
+import org.dcache.nfs.v3.xdr.nfs3_prot;
+import org.dcache.xdr.RpcAuth;
+import org.dcache.xdr.RpcAuthTypeNone;
+import org.dcache.xdr.RpcCall;
+import org.dcache.xdr.XdrTransport;
+import org.mockito.Mockito;
+
+public class RpcCallBuilder {
+    private InetAddressBuilder sourceAddressBuilder = new InetAddressBuilder();
+    private int sourcePort;
+    private int program;
+    private int version;
+    private RpcAuth rpcAuth;
+
+    public RpcCallBuilder nfs3() {
+        this.program = nfs3_prot.NFS_PROGRAM;
+        this.version = nfs3_prot.NFS_V3;
+        return this;
+    }
+
+    public RpcCallBuilder from(String sourceIpAddress, String sourceHostName, int sourcePort) {
+        sourceAddressBuilder.ip(sourceIpAddress).hostName(sourceHostName);
+        this.sourcePort = sourcePort;
+        return this;
+    }
+
+    public RpcCallBuilder noAuth() {
+        rpcAuth = new RpcAuthTypeNone();
+        return this;
+    }
+
+    public RpcCall build() {
+        InetAddress clientAddress = sourceAddressBuilder.build();
+        InetSocketAddress socketAddress = new InetSocketAddress(clientAddress, sourcePort);
+        XdrTransport transport = Mockito.mock(XdrTransport.class);
+        Mockito.when(transport.getRemoteSocketAddress()).thenReturn(socketAddress);
+        return new RpcCall(program, version, rpcAuth, transport);
+    }
+}

--- a/core/src/test/resources/org/dcache/nfs/v3/simpleExports
+++ b/core/src/test/resources/org/dcache/nfs/v3/simpleExports
@@ -1,0 +1,1 @@
+/ *(rw,all_root,sec=none)


### PR DESCRIPTION
as discussed in https://github.com/dCache/jpnfs/issues/5, there are 3 scenarios that result in an NPE in READDIR:
1. vfs implementation returns an empty list of directory entris (technically legal?)
2. client issues read request with very small "count" value, leaving not enough space for even a single entry
3. client attempts a 2nd read request using the cookie+verifier values from the last entry in a previous complete (eof=true) read request

this commit attempts to address all 3, complete with test cases. there are 2 significant changes:
1. execute the entry-list-writing code only if server intends to write actual entries (if startValue < dirList.size()) - this way res.resok.reply.entries is not initialized if no entries are to be written
2. when hitting the client-provided size limit, check to see if any entries have actually been written, and clear res.resok.reply.entries if not
