### PR TITLE
allow VFS access to write stability parameters. chimera VFS always returns FILE_SYNC, as before (issue #12)

### DIFF
--- a/core/src/main/java/org/dcache/nfs/vfs/ChimeraVfs.java
+++ b/core/src/main/java/org/dcache/nfs/vfs/ChimeraVfs.java
@@ -182,9 +182,10 @@ public class ChimeraVfs implements VirtualFileSystem, AclCheckable {
     }
 
     @Override
-    public int write(Inode inode, byte[] data, long offset, int count) throws IOException {
+    public WriteResult write(Inode inode, byte[] data, long offset, int count, StabilityLevel stabilityLevel) throws IOException {
         FsInode fsInode = toFsInode(inode);
-        return fsInode.write(offset, data, 0, count);
+        int bytesWritten = fsInode.write(offset, data, 0, count);
+        return new WriteResult(StabilityLevel.FILE_SYNC, bytesWritten);
     }
 
     @Override

--- a/core/src/main/java/org/dcache/nfs/vfs/PseudoFs.java
+++ b/core/src/main/java/org/dcache/nfs/vfs/PseudoFs.java
@@ -275,9 +275,9 @@ public class PseudoFs implements VirtualFileSystem {
     }
 
     @Override
-    public int write(Inode inode, byte[] data, long offset, int count) throws IOException {
+    public WriteResult write(Inode inode, byte[] data, long offset, int count, StabilityLevel stabilityLevel) throws IOException {
         checkAccess(inode, ACE4_WRITE_DATA);
-        return _inner.write(inode, data, offset, count);
+        return _inner.write(inode, data, offset, count, stabilityLevel);
     }
 
     @Override

--- a/core/src/main/java/org/dcache/nfs/vfs/VfsCache.java
+++ b/core/src/main/java/org/dcache/nfs/vfs/VfsCache.java
@@ -73,8 +73,8 @@ public class VfsCache implements VirtualFileSystem {
     }
 
     @Override
-    public int write(Inode inode, byte[] data, long offset, int count) throws IOException {
-        return _inner.write(inode, data, offset, count);
+    public WriteResult write(Inode inode, byte[] data, long offset, int count, StabilityLevel stabilityLevel) throws IOException {
+        return _inner.write(inode, data, offset, count, stabilityLevel);
     }
 
     @Override


### PR DESCRIPTION
initial impl, as per https://github.com/dCache/jpnfs/issues/12
