### PR TITLE
initial implementation of nfs3 COMMIT

### DIFF
--- a/core/src/main/java/org/dcache/nfs/vfs/ChimeraVfs.java
+++ b/core/src/main/java/org/dcache/nfs/vfs/ChimeraVfs.java
@@ -189,6 +189,11 @@ public class ChimeraVfs implements VirtualFileSystem, AclCheckable {
     }
 
     @Override
+    public void commit(Inode inode, long offset, int count) throws IOException {
+        //nop (all IO is FILE_SYNC so no commits expected)
+    }
+
+    @Override
     public List<DirectoryEntry> list(Inode inode) throws IOException {
         FsInode parentFsInode = toFsInode(inode);
         List<HimeraDirectoryEntry> list = DirectoryStreamHelper.listOf(parentFsInode);

--- a/core/src/main/java/org/dcache/nfs/vfs/PseudoFs.java
+++ b/core/src/main/java/org/dcache/nfs/vfs/PseudoFs.java
@@ -281,6 +281,11 @@ public class PseudoFs implements VirtualFileSystem {
     }
 
     @Override
+    public void commit(Inode inode, long offset, int count) throws IOException {
+        _inner.commit(inode, offset, count);
+    }
+
+    @Override
     public Stat getattr(Inode inode) throws IOException {
         checkAccess(inode, ACE4_READ_ATTRIBUTES);
         return _inner.getattr(inode);

--- a/core/src/main/java/org/dcache/nfs/vfs/VfsCache.java
+++ b/core/src/main/java/org/dcache/nfs/vfs/VfsCache.java
@@ -78,6 +78,11 @@ public class VfsCache implements VirtualFileSystem {
     }
 
     @Override
+    public void commit(Inode inode, long offset, int count) throws IOException {
+        _inner.commit(inode, offset, count);
+    }
+
+    @Override
     public Inode symlink(Inode parent, String path, String link, int uid, int gid, int mode) throws IOException {
         Inode inode = _inner.symlink(parent, path, link, uid, gid, mode);
 	invalidateStatCache(parent);

--- a/core/src/main/java/org/dcache/nfs/vfs/VirtualFileSystem.java
+++ b/core/src/main/java/org/dcache/nfs/vfs/VirtualFileSystem.java
@@ -56,6 +56,8 @@ public interface VirtualFileSystem {
 
     WriteResult write(Inode inode, byte[] data, long offset, int count, StabilityLevel stabilityLevel) throws IOException;
 
+    void commit(Inode inode, long offset, int count) throws IOException;
+
     Stat getattr(Inode inode) throws IOException;
 
     void setattr(Inode inode, Stat stat) throws IOException;


### PR DESCRIPTION
added a commit op to VirtualFileSystem interface.
for chimera commit is a nop since it should never be called (all IO is done FILE_SYNC)
for PseudoFS commit is a pass-through (nfs3 rfc does not include access/permission check for commit)
for VfsCache commit is also pass-through (same as write)
