### PR TITLE
calculate index in the FsExport constructor

### DIFF
--- a/core/src/main/java/org/dcache/nfs/FsExport.java
+++ b/core/src/main/java/org/dcache/nfs/FsExport.java
@@ -58,6 +58,7 @@ public class FsExport {
     private final boolean _allSquash;
     private final int _anonUid;
     private final int _anonGid;
+    private final int _index;
 
     /**
      * NFS clients may be specified in a number of ways:<br>
@@ -105,6 +106,11 @@ public class FsExport {
         _allSquash = builder.hasAllSquash();
         _anonUid = builder.getAnonUid();
         _anonGid = builder.getAnonGid();
+        int index = 1;
+        for (String s: Splitter.on('/').omitEmptyStrings().split(_path) ) {
+            index = 31 * index + s.hashCode();
+        }
+        _index = index;
     }
 
     public String getPath() {
@@ -169,11 +175,7 @@ public class FsExport {
     }
 
     public int getIndex() {
-        int index = 1;
-        for (String s: Splitter.on('/').omitEmptyStrings().split(_path) ) {
-            index = 31 * index + s.hashCode();
-        }
-        return index;
+        return _index;
     }
 
     public boolean checkAcls() {


### PR DESCRIPTION
While debugging slow NFS performance accompanied by high CPU usage noticed that FsExport.getIndex() determines some index on every call from what seems like immutable data. Moved it to constructor.

Target: master
Request: 0.7
Acked-by: Paul Millar paul.millar@desy.de Albert Rossi arossi@fnal.gov
Patch: https://rb.dcache.org/r/7372/
(cherry picked from commit 1ee6f7a2b91725ddee7801d5383b86039829b208)

Conflicts:
    core/src/main/java/org/dcache/nfs/FsExport.java
