### PR TITLE
avoid extra copy of data buffer in nfs3.read

### DIFF
--- a/core/src/main/java/org/dcache/nfs/v3/NfsServerV3.java
+++ b/core/src/main/java/org/dcache/nfs/v3/NfsServerV3.java
@@ -1072,7 +1072,6 @@ public class NfsServerV3 extends nfs3_protServerStub {
             long offset = arg1.offset.value.value;
             int count = arg1.count.value.value;
 
-            UnixUser user = NfsUser.remoteUser(call$, _exports);
             Stat inodeStat = fs.getattr(inode);
 
             res.resok = new READ3resok();
@@ -1086,10 +1085,12 @@ public class NfsServerV3 extends nfs3_protServerStub {
             if (res.resok.count.value.value < 0) {
                 throw new NfsIoException("IO not allowed");
             }
-            res.resok.data = new byte[res.resok.count.value.value];
-
-
-            System.arraycopy(b, 0, res.resok.data, 0, res.resok.count.value.value);
+            if (res.resok.count.value.value == count) {
+                res.resok.data = b;
+            } else {
+                res.resok.data = new byte[res.resok.count.value.value];
+                System.arraycopy(b, 0, res.resok.data, 0, res.resok.count.value.value);
+            }
 
             if (res.resok.count.value.value + offset == inodeStat.getSize()) {
                 res.resok.eof = true;


### PR DESCRIPTION
for the case where # of bytes read == count the copy is definitely not required.
i dont know if nfs allows returning a buffer larger than the amount of actual data in it (on the one hand there is a count field in the response, on the other the rfc says nothing) - so i left the copy in place for those cases. however, i think that bytesRead==count should be fairly common for files larger then the max buffer size (32k by default).

i've also removed an unused UnixUser.
