### PR TITLE
make cleanup threads daemons

### DIFF
--- a/core/src/main/java/org/dcache/utils/Cache.java
+++ b/core/src/main/java/org/dcache/utils/Cache.java
@@ -201,6 +201,7 @@ public class Cache<K, V> implements Runnable {
         _cleanerScheduler = Executors.newSingleThreadScheduledExecutor(
                 new ThreadFactoryBuilder()
                         .setNameFormat(name + " periodic cleanup")
+                        .setDaemon(true)
                         .build()
         );
         _cleanerScheduler.scheduleAtFixedRate(this, timeValue, timeValue, timeUnit);


### PR DESCRIPTION
currently the nfs4 session cleanup thread is not a daemon.
this prevents proper termination of a jvm running an nfs4 server in certain situations, like the classic:

```java
public static void main (String[] args) {
    OncRpcSvc server = createAndStartServer();
    System.in.read(); //hit any key to shut down
    server.stop();
    //main will exit, but jvm will stay alive because of the nfs4 session cleanup thread
}
```