### PR TITLE
respect the gid and uid sent in creation attributes

### DIFF
--- a/core/src/main/java/org/dcache/nfs/vfs/PseudoFs.java
+++ b/core/src/main/java/org/dcache/nfs/vfs/PseudoFs.java
@@ -143,6 +143,10 @@ public class PseudoFs extends ForwardingFileSystem {
     public Inode create(Inode parent, Stat.Type type, String path, Subject subject, int mode) throws IOException {
         Subject effectiveSubject = checkAccess(parent, ACE4_ADD_FILE);
 
+        if (subject != null && Subjects.isRoot(effectiveSubject)) {
+            effectiveSubject = subject;
+        }
+
         if (inheritUidGid(parent)) {
             Stat s = _inner.getattr(parent);
             effectiveSubject = Subjects.of(s.getUid(), s.getGid());
@@ -208,6 +212,10 @@ public class PseudoFs extends ForwardingFileSystem {
     @Override
     public Inode mkdir(Inode parent, String path, Subject subject, int mode) throws IOException {
         Subject effectiveSubject = checkAccess(parent, ACE4_ADD_SUBDIRECTORY);
+        if (subject != null && Subjects.isRoot(effectiveSubject)) {
+            effectiveSubject = subject;
+        }
+
         if (inheritUidGid(parent)) {
             Stat s = _inner.getattr(parent);
             effectiveSubject = Subjects.of(s.getUid(), s.getGid());


### PR DESCRIPTION
This originates form using SimpleNfsServer in https://github.com/kofemann/simple-nfs to implement a local nfs server to test an nfs v3 client application. Our client was doing a directory creation as root, but was sending different uid and gid for the directory creation. The SimpleNfsServer ignored that and created the directory with root uid and gid. I tracked the root cause to PseudoFs ignoring the attributes received on creation.
The suggested fix is prettry simple but maybe I am optimistic here and a more general solution is needed here. Let me know what you think.
One thing is that I am not sure this should be allowed to all users, maybe only root, I can add that check if needed.