### PR TITLE
nfs4: set response committed value properly in op COMMIT based on VFS WriteResult return value

### DIFF
--- a/core/src/main/java/org/dcache/nfs/v4/OperationWRITE.java
+++ b/core/src/main/java/org/dcache/nfs/v4/OperationWRITE.java
@@ -89,7 +89,7 @@ public class OperationWRITE extends AbstractNFSv4Operation {
         res.status = nfsstat.NFS_OK;
         res.resok4 = new WRITE4resok();
         res.resok4.count = new count4(writeResult.getBytesWritten());
-        res.resok4.committed = stable_how4.FILE_SYNC4;
+        res.resok4.committed = writeResult.getStabilityLevel().toStableHow();
         res.resok4.writeverf = context.getRebootVerifier();
 
     }


### PR DESCRIPTION
I'm trying to implement a VirtualFileSystem with UNSTABLE writing support, but commit is never called by client because of this hardcoded value.