### PR TITLE
Fixed inability to mount on Windows

### DIFF
--- a/core/src/main/java/org/dcache/nfs/v3/MountServer.java
+++ b/core/src/main/java/org/dcache/nfs/v3/MountServer.java
@@ -83,7 +83,9 @@ public class MountServer extends mount_protServerStub {
 
         mountres3 m = new mountres3();
 
-        String mountPoint = arg1.value;
+        java.io.File f = new java.io.File(arg1.value);
+        String mountPoint = f.getPath().replace("\\", "/");
+
         InetAddress remoteAddress = call$.getTransport().getRemoteSocketAddress().getAddress();
         _log.debug("Mount request for: {}", mountPoint);
 

--- a/core/src/main/java/org/dcache/nfs/v3/MountServer.java
+++ b/core/src/main/java/org/dcache/nfs/v3/MountServer.java
@@ -38,6 +38,8 @@ import org.dcache.nfs.v3.xdr.groupnode;
 import org.dcache.nfs.v3.xdr.mountres3_ok;
 import org.dcache.nfs.v3.xdr.mountstat3;
 import java.net.InetAddress;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -83,8 +85,8 @@ public class MountServer extends mount_protServerStub {
 
         mountres3 m = new mountres3();
 
-        java.io.File f = new java.io.File(arg1.value);
-        String mountPoint = f.getPath().replace("\\", "/");
+        Path p = Paths.get(arg1.value);
+        String mountPoint = p.toString().replace("\\", "/");
 
         InetAddress remoteAddress = call$.getTransport().getRemoteSocketAddress().getAddress();
         _log.debug("Mount request for: {}", mountPoint);

--- a/core/src/main/java/org/dcache/nfs/v3/MountServer.java
+++ b/core/src/main/java/org/dcache/nfs/v3/MountServer.java
@@ -83,8 +83,7 @@ public class MountServer extends mount_protServerStub {
 
         mountres3 m = new mountres3();
 
-        java.io.File f = new java.io.File(arg1.value);
-        String mountPoint = f.getAbsolutePath();
+        String mountPoint = arg1.value;
         InetAddress remoteAddress = call$.getTransport().getRemoteSocketAddress().getAddress();
         _log.debug("Mount request for: {}", mountPoint);
 


### PR DESCRIPTION
On Windows, the JDK's File.getAbsolutePath() method will create a String that has a Windows style path, including a drive letter. E.g. C:\My\Exported\Path.  Because nfs4j uses a completely virtual filesystem, the entries in the exports file are completely arbitrary and not bound to any real path. For this reason, I believe simply using the passed in argument is enough to use as a matcher for the export file.  I noticed the unmount does this anyway.