### PR TITLE
Modified V3 Components to Use ExportTable

### DIFF
--- a/core/src/main/java/org/dcache/nfs/v3/MountServer.java
+++ b/core/src/main/java/org/dcache/nfs/v3/MountServer.java
@@ -44,7 +44,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import org.dcache.nfs.ChimeraNFSException;
-import org.dcache.nfs.ExportFile;
+import org.dcache.nfs.ExportTable;
 import org.dcache.nfs.FsExport;
 import org.dcache.nfs.status.*;
 import org.dcache.nfs.vfs.Inode;
@@ -58,7 +58,7 @@ import org.slf4j.LoggerFactory;
 public class MountServer extends mount_protServerStub {
 
     private static final Logger _log = LoggerFactory.getLogger(MountServer.class);
-    private final ExportFile _exportFile;
+    private final ExportTable _exports;
     private final Multimap<String, InetAddress> _mounts = HashMultimap.create();
     private final VirtualFileSystem _vfs;
 
@@ -69,9 +69,9 @@ public class MountServer extends mount_protServerStub {
     public final static int RPC_AUTH_GSS_KRB5I = 390004;
     public final static int RPC_AUTH_GSS_KRB5P = 390005;
 
-    public MountServer(ExportFile exportFile, VirtualFileSystem fs) {
+    public MountServer(ExportTable exports, VirtualFileSystem fs) {
         super();
-        _exportFile = exportFile;
+        _exports = exports;
         _vfs = fs;
     }
 
@@ -91,7 +91,7 @@ public class MountServer extends mount_protServerStub {
         InetAddress remoteAddress = call$.getTransport().getRemoteSocketAddress().getAddress();
         _log.debug("Mount request for: {}", mountPoint);
 
-        FsExport export = _exportFile.getExport(mountPoint, remoteAddress);
+        FsExport export = _exports.getExport(mountPoint, remoteAddress);
         if (export == null) {
             m.fhs_status = mountstat3.MNT3ERR_ACCES;
             _log.info("Mount deny for: {}:{}", remoteAddress, mountPoint);
@@ -176,7 +176,7 @@ public class MountServer extends mount_protServerStub {
 
         eList.value = null;
 
-        Map<String, List<FsExport>> exports = _exportFile
+        Map<String, List<FsExport>> exports = _exports
                 .exports()
                 .collect(Collectors.groupingBy(FsExport::getPath));
 

--- a/core/src/main/java/org/dcache/nfs/v3/NfsServerV3.java
+++ b/core/src/main/java/org/dcache/nfs/v3/NfsServerV3.java
@@ -21,6 +21,7 @@ package org.dcache.nfs.v3;
 
 import org.dcache.auth.Subjects;
 import org.dcache.nfs.ExportFile;
+import org.dcache.nfs.ExportTable;
 import org.dcache.nfs.nfsstat;
 import org.dcache.nfs.ChimeraNFSException;
 import org.dcache.nfs.v3.xdr.LOOKUP3res;
@@ -164,11 +165,11 @@ public class NfsServerV3 extends nfs3_protServerStub {
     private static final Logger _log = LoggerFactory.getLogger(NfsServerV3.class);
 
     private final VirtualFileSystem _vfs;
-    private final ExportFile _exports;
+    private final ExportTable _exports;
 
     private final writeverf3 writeVerifier = generateInstanceWriteVerifier();
 
-    public NfsServerV3(ExportFile exports, VirtualFileSystem fs) {
+    public NfsServerV3(ExportTable exports, VirtualFileSystem fs) {
         _vfs = fs;
         _exports = exports;
     }

--- a/core/src/main/java/org/dcache/nfs/v3/NfsServerV3.java
+++ b/core/src/main/java/org/dcache/nfs/v3/NfsServerV3.java
@@ -20,7 +20,6 @@
 package org.dcache.nfs.v3;
 
 import org.dcache.auth.Subjects;
-import org.dcache.nfs.ExportFile;
 import org.dcache.nfs.ExportTable;
 import org.dcache.nfs.nfsstat;
 import org.dcache.nfs.ChimeraNFSException;
@@ -126,7 +125,6 @@ import org.dcache.nfs.v3.xdr.CREATE3resfail;
 import org.dcache.nfs.v3.xdr.FSINFO3resfail;
 import org.dcache.nfs.v3.xdr.ACCESS3res;
 import org.dcache.nfs.v3.xdr.COMMIT3resok;
-import java.io.IOException;
 import java.util.Iterator;
 
 import org.dcache.nfs.v3.xdr.COMMIT3resfail;
@@ -139,7 +137,6 @@ import org.dcache.nfs.vfs.VirtualFileSystem;
 import org.dcache.nfs.vfs.Stat;
 import org.dcache.nfs.status.*;
 import org.dcache.oncrpc4j.util.Bytes;
-import org.dcache.oncrpc4j.rpc.OncRpcException;
 import org.dcache.oncrpc4j.rpc.RpcCall;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
We liked the new ExportTable interface as it lets us use a custom implementation instead of ExportFile and seems useful to use it in the V3 components as well.  Seems a rather harmless change given that ExportFile implements it.