### PR TITLE
Extract interface for client cache to allow custom implementations. S…

### DIFF
--- a/core/src/main/java/org/dcache/nfs/v4/ClientCache.java
+++ b/core/src/main/java/org/dcache/nfs/v4/ClientCache.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020 iterate GmbH
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this program (see the file COPYING.LIB for more
+ * details); if not, write to the Free Software Foundation, Inc.,
+ * 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+package org.dcache.nfs.v4;
+
+import org.dcache.nfs.v4.xdr.clientid4;
+
+import java.util.stream.Stream;
+
+public interface ClientCache {
+
+    /**
+     * Cache client by id
+     *
+     * @param clientid4  Client id
+     * @param nfs4Client Client reference
+     */
+    void put(clientid4 clientid4, NFS4Client nfs4Client);
+
+    /**
+     * @param clientid4 Client id
+     * @return Cached client or null if not found
+     */
+    NFS4Client get(clientid4 clientid4);
+
+    /**
+     * Remove client by id
+     *
+     * @param clientid4 Client id
+     * @return Previously cached client if any
+     */
+    NFS4Client remove(clientid4 clientid4);
+
+    /**
+     * Check and remove expired entries.
+     */
+    void cleanUp();
+
+    /**
+     * @return Return cached clients and update last access time for elements retrieved.
+     */
+    Stream<NFS4Client> stream();
+
+    /**
+     * @return Return cached clients. The last access time of the element will not be updated.
+     */
+    Stream<NFS4Client> peek();
+}

--- a/core/src/main/java/org/dcache/nfs/v4/DefaultClientCache.java
+++ b/core/src/main/java/org/dcache/nfs/v4/DefaultClientCache.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020 iterate GmbH
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this program (see the file COPYING.LIB for more
+ * details); if not, write to the Free Software Foundation, Inc.,
+ * 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+package org.dcache.nfs.v4;
+
+import org.dcache.nfs.util.Cache;
+import org.dcache.nfs.util.CacheElement;
+import org.dcache.nfs.util.CacheEventListener;
+import org.dcache.nfs.v4.xdr.clientid4;
+
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+public class DefaultClientCache extends Cache<clientid4, NFS4Client> implements ClientCache {
+    public DefaultClientCache(int leaseTime, CacheEventListener<clientid4, NFS4Client> eventListener) {
+        super("NFSv41 clients", 5000, Long.MAX_VALUE,
+                TimeUnit.SECONDS.toMillis(leaseTime * 2),
+                eventListener);
+    }
+
+    @Override
+    public Stream<NFS4Client> stream() {
+        return entries().stream()
+                .map(CacheElement::getObject);
+    }
+
+    @Override
+    public Stream<NFS4Client> peek() {
+        return entries().stream()
+                .map(CacheElement::peekObject);
+    }
+}


### PR DESCRIPTION
…ee #37 for reasons of possible other lax implementations with non expiring client leases.

Signed-off-by: David Kocher <dkocher@iterate.ch>