### PR TITLE
Allow virtual filesystem to check user subject.

### DIFF
--- a/core/src/main/java/org/dcache/nfs/v3/NfsServerV3.java
+++ b/core/src/main/java/org/dcache/nfs/v3/NfsServerV3.java
@@ -210,7 +210,7 @@ public class NfsServerV3 extends nfs3_protServerStub {
 
             HimeraNfsUtils.fill_attributes(objStat, res.resok.obj_attributes.attributes);
 
-            int realAccess = fs.access(inode,  arg1.access.value);
+            int realAccess = fs.access(call$.getCredential().getSubject(), inode,  arg1.access.value);
 
             res.resok.access = new uint32(realAccess);
         } catch (ChimeraNFSException hne) {

--- a/core/src/main/java/org/dcache/nfs/v4/OperationACCESS.java
+++ b/core/src/main/java/org/dcache/nfs/v4/OperationACCESS.java
@@ -61,7 +61,7 @@ public class OperationACCESS extends AbstractNFSv4Operation {
             throw new InvalException("invalid access mask");
         }
 
-        final int realAccess = context.getFs().access(context.currentInode(), requestedAccess);
+        final int realAccess = context.getFs().access(context.getSubject(), context.currentInode(), requestedAccess);
 
         _log.debug("NFS Request ACCESS uid: {} {} {}",
                     context.getSubject(), requestedAccess, realAccess );

--- a/core/src/main/java/org/dcache/nfs/v4/OperationOPEN.java
+++ b/core/src/main/java/org/dcache/nfs/v4/OperationOPEN.java
@@ -183,7 +183,7 @@ public class OperationOPEN extends AbstractNFSv4Operation {
                                     Integer.toOctalString(fileStat.getMode() & 0777));
                         }
 
-                        if (context.getFs().access(inode, nfs4_prot.ACCESS4_MODIFY) == 0) {
+                        if (context.getFs().access(context.getSubject(), inode, nfs4_prot.ACCESS4_MODIFY) == 0) {
                             throw new AccessException();
                         }
 
@@ -297,7 +297,7 @@ public class OperationOPEN extends AbstractNFSv4Operation {
                 throw new InvalException("Invalid share_access mode: " + share_access.value);
         }
 
-        if (context.getFs().access(inode, accessMode) != accessMode) {
+        if (context.getFs().access(context.getSubject(), inode, accessMode) != accessMode) {
             throw new AccessException();
         }
 

--- a/core/src/main/java/org/dcache/nfs/vfs/ForwardingFileSystem.java
+++ b/core/src/main/java/org/dcache/nfs/vfs/ForwardingFileSystem.java
@@ -42,8 +42,8 @@ public abstract class ForwardingFileSystem implements VirtualFileSystem {
     protected abstract VirtualFileSystem delegate();
 
     @Override
-    public int access(Inode inode, int mode) throws IOException {
-        return delegate().access(inode, mode);
+    public int access(Subject subject, Inode inode, int mode) throws IOException {
+        return delegate().access(subject, inode, mode);
     }
 
     @Override

--- a/core/src/main/java/org/dcache/nfs/vfs/PseudoFs.java
+++ b/core/src/main/java/org/dcache/nfs/vfs/PseudoFs.java
@@ -102,7 +102,7 @@ public class PseudoFs extends ForwardingFileSystem {
     }
 
     @Override
-    public int access(Inode inode, int mode) throws IOException {
+    public int access(Subject subject, Inode inode, int mode) throws IOException {
         int accessmask = 0;
 
         if ((mode & ~ACCESS4_MASK) != 0) {
@@ -171,7 +171,7 @@ public class PseudoFs extends ForwardingFileSystem {
             }
         }
 
-        return accessmask & _inner.access(inode, accessmask);
+        return accessmask & _inner.access(subject, inode, accessmask);
     }
 
     @Override

--- a/core/src/main/java/org/dcache/nfs/vfs/VirtualFileSystem.java
+++ b/core/src/main/java/org/dcache/nfs/vfs/VirtualFileSystem.java
@@ -50,12 +50,14 @@ public interface VirtualFileSystem {
     /**
      * Check access to file system object.
      *
+     *
+     * @param subject User
      * @param inode inode of the object to check.
      * @param mode a mask of permission bits to check.
      * @return an allowed subset of permissions from the given mask.
      * @throws IOException
      */
-    int access(Inode inode, int mode) throws IOException;
+    int access(Subject subject, Inode inode, int mode) throws IOException;
 
     /**
      * Create a new object in a given directory with a specific name.

--- a/core/src/test/java/org/dcache/nfs/vfs/DummyVFS.java
+++ b/core/src/test/java/org/dcache/nfs/vfs/DummyVFS.java
@@ -483,7 +483,7 @@ public class DummyVFS implements VirtualFileSystem {
     }
 
     @Override
-    public int access(Inode inode, int mode) throws IOException {
+    public int access(Subject subject, Inode inode, int mode) throws IOException {
         return mode;
     }
 


### PR DESCRIPTION
Signed-off-by: David Kocher <dkocher@iterate.ch>

This allows the virtual file system to check the `uid` to compare with the user that initiated the mount and prevent access from other users on the system that mount the filesystem.