### PR TITLE
fix testCase StatTest.testToString

### DIFF
--- a/core/src/test/java/org/dcache/nfs/vfs/StatTest.java
+++ b/core/src/test/java/org/dcache/nfs/vfs/StatTest.java
@@ -6,6 +6,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 
 import org.junit.Test;
@@ -30,17 +31,18 @@ public class StatTest {
         localCal.set(Calendar.MILLISECOND, 0);
         stat.setMTime(localCal.getTimeInMillis());
         stat.setMode(0755 | Stat.S_IFDIR);
-        assertEquals("drwxr-xr-x    7    1    2    3 Feb 01 14:15", stat.toString());
+        SimpleDateFormat formatter = new SimpleDateFormat("MMM dd HH:mm");
+        assertEquals("drwxr-xr-x    7    1    2    3 "+formatter.format(localCal.getTime()), stat.toString());
         stat.setMode(0401 | Stat.S_IFREG);
         stat.setNlink(6666);
         stat.setSize(1024*16);
         localCal.set(Calendar.DAY_OF_MONTH, 29);
         localCal.set(Calendar.HOUR_OF_DAY, 1);
         stat.setMTime(localCal.getTimeInMillis());
-        assertEquals("-r-------x 6666    1    2  16K Mar 01 01:15", stat.toString());
+        assertEquals("-r-------x 6666    1    2  16K "+formatter.format(localCal.getTime()), stat.toString());
         stat.setMode(0070 | Stat.S_IFLNK);
         stat.setSize(1024*1024*1024*1024L - 1); //one byte short of 1TB
-        assertEquals("l---rwx--- 6666    1    2 1024G Mar 01 01:15", stat.toString());
+        assertEquals("l---rwx--- 6666    1    2 1024G "+formatter.format(localCal.getTime()), stat.toString());
     }
 
     @Test


### PR DESCRIPTION
handle StatTest.testToString time format differences in different locale