### PR TITLE
Fix typo in error message.

### DIFF
--- a/core/src/main/java/org/dcache/nfs/v4/OperationREAD.java
+++ b/core/src/main/java/org/dcache/nfs/v4/OperationREAD.java
@@ -75,7 +75,7 @@ public class OperationREAD extends AbstractNFSv4Operation {
 
         int bytesReaded = context.getFs().read(context.currentInode(), buf, offset);
         if (bytesReaded < 0) {
-            throw new NfsIoException("IO not allowd");
+            throw new NfsIoException("IO not allowed");
         }
 
         buf.flip();

--- a/core/src/main/java/org/dcache/nfs/v4/ds/DSOperationWRITE.java
+++ b/core/src/main/java/org/dcache/nfs/v4/ds/DSOperationWRITE.java
@@ -90,7 +90,7 @@ public class DSOperationWRITE extends AbstractNFSv4Operation {
         int bytesWritten = out.write(_args.opwrite.data, offset);
 
         if (bytesWritten < 0) {
-            throw new NfsIoException("IO not allowd");
+            throw new NfsIoException("IO not allowed");
         }
 
         res.status = nfsstat.NFS_OK;


### PR DESCRIPTION
`IO not allowd` -> `IO not allowed`