### PR TITLE
LocalFileSystem: Reuse FileStore instance for FsStat

### DIFF
--- a/basic-server/src/main/java/org/dcache/nfs4j/server/LocalFileSystem.java
+++ b/basic-server/src/main/java/org/dcache/nfs4j/server/LocalFileSystem.java
@@ -66,6 +66,7 @@ public class LocalFileSystem implements VirtualFileSystem {
     private static final Logger LOG = LoggerFactory.getLogger(LocalFileSystem.class);
 
     private final Path _root;
+    private final FileStore _store;
     private final NonBlockingHashMapLong<Path> inodeToPath = new NonBlockingHashMapLong<>();
     private final NonBlockingHashMap<Path, Long> pathToInode = new NonBlockingHashMap<>();
     private final AtomicLong fileId = new AtomicLong(1); //numbering starts at 1
@@ -150,6 +151,7 @@ public class LocalFileSystem implements VirtualFileSystem {
     public LocalFileSystem(Path root, Iterable<FsExport> exportIterable) throws IOException {
         _root = root;
         assert (Files.exists(_root));
+        _store = Files.getFileStore(_root);
         for (FsExport export : exportIterable) {
             String relativeExportPath = export.getPath().substring(1); // remove the opening '/'
             Path exportRootPath = root.resolve(relativeExportPath);
@@ -203,9 +205,8 @@ public class LocalFileSystem implements VirtualFileSystem {
 
     @Override
     public FsStat getFsStat() throws IOException {
-        FileStore store = Files.getFileStore(_root);
-        long total = store.getTotalSpace();
-        long free = store.getUsableSpace();
+        long total = _store.getTotalSpace();
+        long free = _store.getUsableSpace();
         return new FsStat(total, Long.MAX_VALUE, total-free, pathToInode.size());
     }
 


### PR DESCRIPTION
Currently, we are calling Files.getFileStore for every request to VirtualFileSystem.getFileStat.

On some systems, such as macOS, this may introduce extremely long wait times for NFS operations, effectively hanging the entire NFS client. Delays as high as 14 seconds (!) have been observed.

Move the FileStore access to LocalFileSystem's constructor, such that it can be reused.

Stack trace for observed hang:
```
	at java.base@22.0.2/sun.nio.fs.BsdNativeDispatcher.getfsstat(Native Method)
	at java.base@22.0.2/sun.nio.fs.BsdFileSystem.getMountEntries(BsdFileSystem.java:169)
	at java.base@22.0.2/sun.nio.fs.BsdFileStore.findMountEntry(BsdFileStore.java:75)
	at java.base@22.0.2/sun.nio.fs.UnixFileStore.<init>(UnixFileStore.java:69)
	at java.base@22.0.2/sun.nio.fs.BsdFileStore.<init>(BsdFileStore.java:42)
	at java.base@22.0.2/sun.nio.fs.BsdFileSystemProvider.getFileStore(BsdFileSystemProvider.java:48)
	at java.base@22.0.2/sun.nio.fs.BsdFileSystemProvider.getFileStore(BsdFileSystemProvider.java:36)
	at java.base@22.0.2/sun.nio.fs.UnixFileSystemProvider.getFileStore(UnixFileSystemProvider.java:422)
	at java.base@22.0.2/java.nio.file.Files.getFileStore(Files.java:1496)
	at app//org.dcache.nfs4j.server.LocalFileSystem.getFsStat(LocalFileSystem.java:209)
	at app//org.dcache.nfs.vfs.ForwardingFileSystem.getFsStat(ForwardingFileSystem.java:57)
	at app//org.dcache.nfs.v4.OperationGETATTR.getFsStat(OperationGETATTR.java:176)
	at app//org.dcache.nfs.v4.OperationGETATTR.fattr2xdr(OperationGETATTR.java:262)
	at app//org.dcache.nfs.v4.OperationGETATTR.getAttributes(OperationGETATTR.java:145)
	at app//org.dcache.nfs.v4.OperationGETATTR.getAttributes(OperationGETATTR.java:169)
	at app//org.dcache.nfs.v4.OperationGETATTR.process(OperationGETATTR.java:124)
	at app//org.dcache.nfs.v4.AbstractOperationExecutor.execute(AbstractOperationExecutor.java:85)
	at app//org.dcache.nfs.v4.NFSServerV41.NFSPROC4_COMPOUND_4(NFSServerV41.java:201)
	at app//org.dcache.nfs.v4.xdr.nfs4_prot_NFS4_PROGRAM_ServerStub.dispatchOncRpcCall(nfs4_prot_NFS4_PROGRAM_ServerStub.java:48)
	at app//org.dcache.oncrpc4j.rpc.RpcDispatcher$1.run(RpcDispatcher.java:122)
	at java.base@22.0.2/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base@22.0.2/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base@22.0.2/java.lang.Thread.runWith(Thread.java:1583)
	at java.base@22.0.2/java.lang.Thread.run(Thread.java:1570)
```