### PR TITLE
Add Eclipse-generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 target
 .idea
 *.iml
+.project
+.settings
+.classpath
+.factorypath


### PR DESCRIPTION
Eclipse creates some metadata files when working with this project.

Since we use Maven integration, these files are automatically generated and should not be included in git.

Add these entries to .gitignore