### PR TITLE
test: Fix tests on Java 21 or newer; replace InetAddress mocking code

### DIFF
--- a/core/src/test/java/org/dcache/nfs/InetAddressMatcherTest.java
+++ b/core/src/test/java/org/dcache/nfs/InetAddressMatcherTest.java
@@ -20,9 +20,9 @@
 package org.dcache.nfs;
 
 import static com.google.common.net.InetAddresses.forString;
-import static org.junit.Assert.*;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -164,11 +164,6 @@ public class InetAddressMatcherTest {
     }
 
     private InetAddress mockInetAddress(String dnsName, String... ips) throws UnknownHostException {
-
-        InetAddress mockedAddress = mock(InetAddress.class);
-        given(mockedAddress.getHostName()).willReturn(dnsName);
-        given(mockedAddress.getCanonicalHostName()).willReturn(dnsName);
-
-        return mockedAddress;
+        return InetAddress.getByAddress(dnsName, InetAddress.getByName(ips[0]).getAddress());
     }
 }

--- a/core/src/test/java/org/dcache/testutils/InetAddressBuilder.java
+++ b/core/src/test/java/org/dcache/testutils/InetAddressBuilder.java
@@ -1,8 +1,7 @@
 package org.dcache.testutils;
 
 import java.net.InetAddress;
-
-import org.mockito.Mockito;
+import java.net.UnknownHostException;
 
 public class InetAddressBuilder {
     private String ipAddress;
@@ -19,9 +18,10 @@ public class InetAddressBuilder {
     }
 
     public InetAddress build() {
-        InetAddress address = Mockito.mock(InetAddress.class);
-        Mockito.when(address.getHostAddress()).thenReturn(ipAddress);
-        Mockito.when(address.getHostName()).thenReturn(hostName);
-        return address;
+        try {
+            return InetAddress.getByAddress(hostName, InetAddress.getByName(ipAddress).getAddress());
+        } catch (UnknownHostException e) {
+            throw new IllegalStateException(e);
+        }
     }
 }


### PR DESCRIPTION
Some unit tests work with fake ("mocked") InetAddress objects, which are currently assembled via mockito. With Java 21 and newer, this is no longer possible.

Replace the mocking code with a new "InetAddressMockery" class that can provide real Inet4Address objects by means of Java object deserialization.

Fixes #144