### PR TITLE
core: Fix regression in handling of export table

### DIFF
--- a/core/src/main/java/org/dcache/nfs/vfs/PseudoFs.java
+++ b/core/src/main/java/org/dcache/nfs/vfs/PseudoFs.java
@@ -753,8 +753,6 @@ public class PseudoFs extends ForwardingFileSystem {
             Inode innerRootInode = _inner.getRootInode();
             if (innerRootInode.getFileIdKey().equals(inode.getFileIdKey())) {
                 return innerRootInode;
-            } else {
-                throw new BadHandleException();
             }
         }
         return Inode.innerInode(inode);


### PR DESCRIPTION
As reported in #156, commit 09e8063234e4b649d3e748474d8d425f53ce64b8 caused a regression a during dCache integration.

The above change uncovered a logic bug in PseudoFS, where we were adding PseudoFS nodes via the inner file system.

Update PseudoFS.pathToPseudoFS to skip paths that don't exist in the inner file system.

Fixes: #156