### PR TITLE
core: Improve access tracking performance for read/write

### DIFF
--- a/core/src/main/java/org/dcache/nfs/util/Opaque.java
+++ b/core/src/main/java/org/dcache/nfs/util/Opaque.java
@@ -199,7 +199,7 @@ public interface Opaque {
     public class OpaqueImpl implements Opaque {
         final byte[] _opaque;
 
-        protected OpaqueImpl(byte[] opaque) {
+        OpaqueImpl(byte[] opaque) {
             _opaque = opaque;
         }
 
@@ -392,13 +392,7 @@ public interface Opaque {
                 }
                 return true;
             } else {
-                Opaque other = (Opaque) o;
-                for (int i = index, n = index + length, oi = 0; i < n; i++, oi++) {
-                    if (buf.get(i) != other.byteAt(oi)) {
-                        return false;
-                    }
-                }
-                return true;
+                return toImmutableOpaque().equals(o);
             }
         }
 

--- a/core/src/main/java/org/dcache/nfs/v4/FileTracker.java
+++ b/core/src/main/java/org/dcache/nfs/v4/FileTracker.java
@@ -475,7 +475,7 @@ public class FileTracker {
         lock.lock();
         try {
 
-            switch (stateid.byteAt(11)) {
+            switch (stateid4.getType(stateid)) {
                 case Stateids.LOCK_STATE_ID:
                     NFS4State lockState = client.state(stateid);
                     stateid = lockState.getOpenState().stateid().getOpaque();

--- a/core/src/main/java/org/dcache/nfs/v4/FileTracker.java
+++ b/core/src/main/java/org/dcache/nfs/v4/FileTracker.java
@@ -341,8 +341,7 @@ public class FileTracker {
             stateid = state.stateid();
             OpenState openState = new OpenState(client, owner, stateid, shareAccess, shareDeny);
             opens.add(openState);
-            Opaque fileIdKey = inode.getFileIdKey();
-            state.addDisposeListener(s -> removeOpen(fileIdKey, stateid));
+            state.addDisposeListener(s -> removeOpen(inode, stateid));
             stateid.bumpSeqid();
 
             // we need to return copy to avoid modification by concurrent opens
@@ -532,10 +531,8 @@ public class FileTracker {
      * @param stateid associated with the open.
      */
     void removeOpen(Inode inode, stateid4 stateid) {
-        removeOpen(inode.getFileIdKey(), stateid);
-    }
 
-    void removeOpen(Opaque fileId, stateid4 stateid) {
+        Opaque fileId = inode.getFileIdKey();
         Lock lock = filesLock.get(fileId);
         lock.lock();
         try {

--- a/core/src/main/java/org/dcache/nfs/v4/NFS4State.java
+++ b/core/src/main/java/org/dcache/nfs/v4/NFS4State.java
@@ -68,7 +68,7 @@ public class NFS4State {
     }
 
     public void bumpSeqid() {
-        ++_stateid.seqid;
+        _stateid.bumpSeqid();
     }
 
     public stateid4 stateid() {

--- a/core/src/main/java/org/dcache/nfs/v4/NFSServerV41.java
+++ b/core/src/main/java/org/dcache/nfs/v4/NFSServerV41.java
@@ -134,7 +134,7 @@ public class NFSServerV41 extends nfs4_prot_NFS4_PROGRAM_ServerStub {
             }
             res.resarray = new ArrayList<>(arg1.argarray.length);
 
-            VirtualFileSystem fs = new PseudoFs(_fs, call$, _exportTable);
+            VirtualFileSystem fs = new PseudoFs(_fs, call$, _exportTable, _statHandler);
 
             CompoundContextBuilder builder = new CompoundContextBuilder()
                     .withMinorversion(arg1.minorversion.value)

--- a/core/src/main/java/org/dcache/nfs/v4/NFSv4StateHandler.java
+++ b/core/src/main/java/org/dcache/nfs/v4/NFSv4StateHandler.java
@@ -481,7 +481,7 @@ public class NFSv4StateHandler {
         // we eat the first 8 bits if the counter, however, we don't expect 16M states be active at the same time,
         // thus the probability of a collision is too low
         Bytes.putInt(other, 8, count << 8 | (type & 0xFF));
-        return stateid4.forBytes(other, STATE_INITIAL_SEQUENCE);
+        return new stateid4(other, STATE_INITIAL_SEQUENCE);
     }
 
     /**

--- a/core/src/main/java/org/dcache/nfs/v4/OperationCLOSE.java
+++ b/core/src/main/java/org/dcache/nfs/v4/OperationCLOSE.java
@@ -59,6 +59,8 @@ public class OperationCLOSE extends AbstractNFSv4Operation {
         NFS4State nfsState = client.state(stateid);
         Stateids.checkStateId(nfsState.stateid(), stateid);
 
+        context.getFs().close(stateid.getOpaque());
+
         if (context.getMinorversion() == 0) {
             nfsState.getStateOwner().acceptAsNextSequence(_args.opclose.seqid);
             client.updateLeaseTime();
@@ -68,6 +70,5 @@ public class OperationCLOSE extends AbstractNFSv4Operation {
 
         res.open_stateid = Stateids.invalidStateId();
         res.status = nfsstat.NFS_OK;
-
     }
 }

--- a/core/src/main/java/org/dcache/nfs/v4/OperationCLOSE.java
+++ b/core/src/main/java/org/dcache/nfs/v4/OperationCLOSE.java
@@ -29,6 +29,7 @@ import org.dcache.nfs.v4.xdr.nfs_opnum4;
 import org.dcache.nfs.v4.xdr.nfs_resop4;
 import org.dcache.nfs.v4.xdr.stateid4;
 import org.dcache.nfs.vfs.Inode;
+import org.dcache.nfs.vfs.VirtualFileSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +60,10 @@ public class OperationCLOSE extends AbstractNFSv4Operation {
         NFS4State nfsState = client.state(stateid);
         Stateids.checkStateId(nfsState.stateid(), stateid);
 
-        context.getFs().close(stateid.getOpaque());
+        VirtualFileSystem fs = context.getFs();
+        if (fs != null) {
+            fs.close(stateid.getOpaque());
+        }
 
         if (context.getMinorversion() == 0) {
             nfsState.getStateOwner().acceptAsNextSequence(_args.opclose.seqid);

--- a/core/src/main/java/org/dcache/nfs/v4/OperationCOMMIT.java
+++ b/core/src/main/java/org/dcache/nfs/v4/OperationCOMMIT.java
@@ -28,6 +28,7 @@ import org.dcache.nfs.v4.xdr.COMMIT4resok;
 import org.dcache.nfs.v4.xdr.nfs_argop4;
 import org.dcache.nfs.v4.xdr.nfs_opnum4;
 import org.dcache.nfs.v4.xdr.nfs_resop4;
+import org.dcache.nfs.v4.xdr.stateid4;
 import org.dcache.nfs.vfs.Inode;
 
 public class OperationCOMMIT extends AbstractNFSv4Operation {
@@ -42,8 +43,11 @@ public class OperationCOMMIT extends AbstractNFSv4Operation {
         final COMMIT4res res = result.opcommit;
         Inode inode = context.currentInode();
 
+        stateid4 stateid = Stateids.getCurrentStateidIfNeeded(context, _args.opwrite.stateid);
+
         _args.opcommit.offset.checkOverflow(_args.opcommit.count.value, "offset + length overflow");
-        context.getFs().commit(inode, _args.opcommit.offset.value, _args.opcommit.count.value);
+        context.getFs().commit(stateid.getOpaque(), inode, _args.opcommit.offset.value,
+                _args.opcommit.count.value);
 
         res.resok4 = new COMMIT4resok();
         res.resok4.writeverf = context.getRebootVerifier();

--- a/core/src/main/java/org/dcache/nfs/v4/OperationREAD.java
+++ b/core/src/main/java/org/dcache/nfs/v4/OperationREAD.java
@@ -73,7 +73,7 @@ public class OperationREAD extends AbstractNFSv4Operation {
         ByteBuffer buf = ByteBuffer.allocate(count);
 
         res.resok4 = new READ4resok();
-        int bytesRead = context.getFs().read(inode, buf, offset, res.resok4::setEOF);
+        int bytesRead = context.getFs().read(stateid.getOpaque(), inode, buf, offset, res.resok4::setEOF);
 
         if (bytesRead < 0) {
             buf.clear();

--- a/core/src/main/java/org/dcache/nfs/v4/OperationTEST_STATEID.java
+++ b/core/src/main/java/org/dcache/nfs/v4/OperationTEST_STATEID.java
@@ -53,7 +53,7 @@ public class OperationTEST_STATEID extends AbstractNFSv4Operation {
             stateid4 statid = _args.optest_stateid.ts_stateids[i];
             try {
                 NFS4State state = client.state(statid);
-                if (state.stateid().seqid < statid.seqid) {
+                if (state.stateid().getSeqId() < statid.getSeqId()) {
                     res.tsr_resok4.tsr_status_codes[i] = nfsstat.NFSERR_OLD_STATEID;
                 } else {
                     res.tsr_resok4.tsr_status_codes[i] = nfsstat.NFS_OK;

--- a/core/src/main/java/org/dcache/nfs/v4/OperationWRITE.java
+++ b/core/src/main/java/org/dcache/nfs/v4/OperationWRITE.java
@@ -87,7 +87,8 @@ public class OperationWRITE extends AbstractNFSv4Operation {
         }
 
         long offset = _args.opwrite.offset.value;
-        VirtualFileSystem.WriteResult writeResult = context.getFs().write(context.currentInode(),
+        VirtualFileSystem.WriteResult writeResult = context.getFs().write(
+                stateid.getOpaque(), context.currentInode(),
                 _args.opwrite.data, offset, VirtualFileSystem.StabilityLevel.fromStableHow(_args.opwrite.stable));
 
         if (writeResult.getBytesWritten() < 0) {

--- a/core/src/main/java/org/dcache/nfs/v4/Stateids.java
+++ b/core/src/main/java/org/dcache/nfs/v4/Stateids.java
@@ -56,18 +56,18 @@ public class Stateids {
     }
 
     private final static stateid4 CURRENT_STATEID =
-            new stateid4(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1);
+            stateid4.forBytes(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1);
     private final static stateid4 INVAL_STATEID =
-            new stateid4(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, nfs4_prot.NFS4_UINT32_MAX);
+            stateid4.forBytes(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, nfs4_prot.NFS4_UINT32_MAX);
     private final static stateid4 ZERO_STATEID =
-            new stateid4(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0);
+            stateid4.forBytes(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0);
 
-    private final static stateid4 ONE_STATEID = new stateid4(new byte[] {
+    private final static stateid4 ONE_STATEID = stateid4.forBytes(new byte[] {
             (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
             (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff}, nfs4_prot.NFS4_UINT32_MAX);
 
     public static stateid4 uptodateOf(stateid4 stateid) {
-        return new stateid4(stateid.other, 0);
+        return stateid4.forBytes(stateid.getOpaque().toBytes(), 0);
     }
 
     public static stateid4 currentStateId() {
@@ -91,16 +91,17 @@ public class Stateids {
     }
 
     public static void checkStateId(stateid4 expected, stateid4 stateid) throws ChimeraNFSException {
-        if (stateid.seqid == 0) {
+        int seq = stateid.getSeqId();
+        if (seq == 0) {
             // so called 'most up-to-date seqid', see https://tools.ietf.org/html/rfc5661#section-8.2.2
             return;
         }
 
-        if (expected.seqid > stateid.seqid) {
-            throw new OldStateidException();
-        }
+        int expectedSeq = expected.getSeqId();
 
-        if (expected.seqid < stateid.seqid) {
+        if (expectedSeq > seq) {
+            throw new OldStateidException();
+        } else if (expectedSeq != seq) {
             throw new BadStateidException();
         }
     }
@@ -114,37 +115,37 @@ public class Stateids {
     }
 
     public static void checkOpenStateid(stateid4 stateid) throws BadStateidException {
-        if (stateid.other[11] != OPEN_STATE_ID) {
+        if (stateid.getType() != OPEN_STATE_ID) {
             throw new BadStateidException("Not an open stateid");
         }
     }
 
     public static void checkLockStateid(stateid4 stateid) throws BadStateidException {
-        if (stateid.other[11] != LOCK_STATE_ID) {
+        if (stateid.getType() != LOCK_STATE_ID) {
             throw new BadStateidException("Not a lock stateid");
         }
     }
 
     public static void checkDelegationStateid(stateid4 stateid) throws BadStateidException {
-        if (stateid.other[11] != DELEGATION_STATE_ID) {
+        if (stateid.getType() != DELEGATION_STATE_ID) {
             throw new BadStateidException("Not a delegation stateid");
         }
     }
 
     public static void checkDirDelegationStateid(stateid4 stateid) throws BadStateidException {
-        if (stateid.other[11] != DIR_DELEGATION_STATE_ID) {
+        if (stateid.getType() != DIR_DELEGATION_STATE_ID) {
             throw new BadStateidException("Not a directory delegation stateid");
         }
     }
 
     public static void checkServerSiderCopyStateid(stateid4 stateid) throws BadStateidException {
-        if (stateid.other[11] != SSC_STATE_ID) {
+        if (stateid.getType() != SSC_STATE_ID) {
             throw new BadStateidException("Not a server-side copy stateid");
         }
     }
 
     public static void checkLayoutStateid(stateid4 stateid) throws BadStateidException {
-        if (stateid.other[11] != LAYOUT_STATE_ID) {
+        if (stateid.getType() != LAYOUT_STATE_ID) {
             throw new BadStateidException("Not a layout stateid");
         }
     }

--- a/core/src/main/java/org/dcache/nfs/v4/Stateids.java
+++ b/core/src/main/java/org/dcache/nfs/v4/Stateids.java
@@ -56,18 +56,18 @@ public class Stateids {
     }
 
     private final static stateid4 CURRENT_STATEID =
-            stateid4.forBytes(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1);
+            new stateid4(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 1);
     private final static stateid4 INVAL_STATEID =
-            stateid4.forBytes(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, nfs4_prot.NFS4_UINT32_MAX);
+            new stateid4(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, nfs4_prot.NFS4_UINT32_MAX);
     private final static stateid4 ZERO_STATEID =
-            stateid4.forBytes(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0);
+            new stateid4(new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0);
 
-    private final static stateid4 ONE_STATEID = stateid4.forBytes(new byte[] {
+    private final static stateid4 ONE_STATEID = new stateid4(new byte[] {
             (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff,
             (byte) 0xff, (byte) 0xff, (byte) 0xff, (byte) 0xff}, nfs4_prot.NFS4_UINT32_MAX);
 
     public static stateid4 uptodateOf(stateid4 stateid) {
-        return stateid4.forBytes(stateid.getOpaque().toBytes(), 0);
+        return new stateid4(stateid.getOpaque().toBytes(), 0);
     }
 
     public static stateid4 currentStateId() {

--- a/core/src/main/java/org/dcache/nfs/v4/xdr/stateid4.java
+++ b/core/src/main/java/org/dcache/nfs/v4/xdr/stateid4.java
@@ -78,6 +78,10 @@ public class stateid4 implements XdrAble, Serializable, Cloneable {
         return opaque.byteAt(11);
     }
 
+    public static int getType(Opaque stateIdOther) {
+        return stateIdOther.byteAt(11);
+    }
+
     @Override
     public stateid4 clone() {
         return new stateid4(seqid, opaque);

--- a/core/src/main/java/org/dcache/nfs/v4/xdr/stateid4.java
+++ b/core/src/main/java/org/dcache/nfs/v4/xdr/stateid4.java
@@ -39,16 +39,11 @@ public class stateid4 implements XdrAble, Serializable, Cloneable {
     private byte[] other; // only declared for Java Serialization
     private transient Opaque opaque;
 
-    public static stateid4 forBytes(byte[] bytes, int seqid) {
-        return new stateid4(seqid, Opaque.forBytes(bytes));
-    }
-
     public stateid4(XdrDecodingStream xdr) throws OncRpcException, IOException {
         this.seqid = xdr.xdrDecodeInt();
         this.opaque = Opaque.forBytes(xdr.xdrDecodeOpaque(12));
     }
 
-    @Deprecated(forRemoval = true)
     public stateid4(byte[] bytes, int seqid) {
         this(seqid, Opaque.forBytes(bytes));
     }

--- a/core/src/main/java/org/dcache/nfs/v4/xdr/stateid4.java
+++ b/core/src/main/java/org/dcache/nfs/v4/xdr/stateid4.java
@@ -91,7 +91,8 @@ public class stateid4 implements XdrAble, Serializable, Cloneable {
 
     public void xdrDecode(XdrDecodingStream xdr)
             throws OncRpcException, IOException {
-        throw new UnsupportedOperationException("Use constructor");
+        seqid = xdr.xdrDecodeInt();
+        opaque = Opaque.forBytes(xdr.xdrDecodeOpaque(12));
     }
 
     @Override

--- a/core/src/main/java/org/dcache/nfs/vfs/ForwardingFileSystem.java
+++ b/core/src/main/java/org/dcache/nfs/vfs/ForwardingFileSystem.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.security.auth.Subject;
 
+import org.dcache.nfs.util.Opaque;
 import org.dcache.nfs.v4.NfsIdMapping;
 import org.dcache.nfs.v4.xdr.nfsace4;
 import org.dcache.nfs.vfs.Stat.StatAttribute;
@@ -107,8 +108,8 @@ public abstract class ForwardingFileSystem implements VirtualFileSystem {
     }
 
     @Override
-    public int read(Inode inode, ByteBuffer data, long offset, Runnable eofReached) throws IOException {
-        return delegate().read(inode, data, offset, eofReached);
+    public int read(Opaque stateId, Inode inode, ByteBuffer data, long offset, Runnable eofReached) throws IOException {
+        return delegate().read(stateId, inode, data, offset, eofReached);
     }
 
     @Override
@@ -139,8 +140,19 @@ public abstract class ForwardingFileSystem implements VirtualFileSystem {
     }
 
     @Override
+    public WriteResult write(Opaque stateId, Inode inode, ByteBuffer data, long offset, StabilityLevel stabilityLevel)
+            throws IOException {
+        return delegate().write(stateId, inode, data, offset, stabilityLevel);
+    }
+
+    @Override
     public void commit(Inode inode, long offset, int count) throws IOException {
         delegate().commit(inode, offset, count);
+    }
+
+    @Override
+    public void commit(Opaque stateId, Inode inode, long offset, int count) throws IOException {
+        delegate().commit(stateId, inode, offset, count);
     }
 
     @Override
@@ -221,5 +233,15 @@ public abstract class ForwardingFileSystem implements VirtualFileSystem {
     @Override
     public CompletableFuture<Long> copyFileRange(Inode src, long srcPos, Inode dst, long dstPos, long len) {
         return delegate().copyFileRange(src, srcPos, dst, dstPos, len);
+    }
+
+    @Override
+    public void open(Opaque stateId, Inode inode, OpenMode openMode) {
+        delegate().open(stateId, inode, openMode);
+    }
+
+    @Override
+    public void close(Opaque stateId) {
+        delegate().close(stateId);
     }
 }

--- a/core/src/main/java/org/dcache/nfs/vfs/PseudoFs.java
+++ b/core/src/main/java/org/dcache/nfs/vfs/PseudoFs.java
@@ -823,12 +823,12 @@ public class PseudoFs extends ForwardingFileSystem {
     }
 
     /**
-     * Convert an {@link Inode} that is used by {@link PseudoFs} to an {@link Inode} that is understood by the
-     * underlying file system.
+     * Convert an {@link Inode} that is used by {@link PseudoFs} to an {@link Inode} that is understood
+     * by the underlying file system.
      * <p>
      * We currently store additional information such as "ExportId" and "PseudoInode" as parts of the Inode.
-     * {@link VirtualFileSystem}s that store {@link Inode} as a whole (rather than only the "fileId" bit) may not
-     * recognize such objects, unless we remove this additional information.
+     * {@link VirtualFileSystem}s that store {@link Inode} as a whole (rather than only the "fileId" bit)
+     * may not recognize such objects, unless we remove this additional information.
      * <p>
      * Once {@link PseudoFs} handles this configuration internally, we can remove this conversion step.
      *

--- a/core/src/test/java/org/dcache/nfs/v4/OperationREADTest.java
+++ b/core/src/test/java/org/dcache/nfs/v4/OperationREADTest.java
@@ -1,16 +1,8 @@
 package org.dcache.nfs.v4;
 
-import static org.dcache.nfs.v4.NfsTestUtils.execute;
+import static org.dcache.nfs.v4.NfsTestUtils.*;
 import static org.dcache.nfs.v4.NfsTestUtils.generateRpcCall;
-import static org.dcache.nfs.v4.NfsTestUtils.generateStateId;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.net.UnknownHostException;

--- a/core/src/test/java/org/dcache/nfs/v4/OperationREADTest.java
+++ b/core/src/test/java/org/dcache/nfs/v4/OperationREADTest.java
@@ -1,8 +1,16 @@
 package org.dcache.nfs.v4;
 
-import static org.dcache.nfs.v4.NfsTestUtils.*;
+import static org.dcache.nfs.v4.NfsTestUtils.execute;
 import static org.dcache.nfs.v4.NfsTestUtils.generateRpcCall;
-import static org.mockito.Mockito.*;
+import static org.dcache.nfs.v4.NfsTestUtils.generateStateId;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
@@ -54,7 +62,7 @@ public class OperationREADTest {
         FileTracker fileTracker = mock(FileTracker.class);
 
         when(stateHandler.getFileTracker()).thenReturn(fileTracker);
-        when(fileTracker.getShareAccess(any(), any(), any())).thenReturn(nfs4_prot.OPEN4_SHARE_ACCESS_READ);
+        when(fileTracker.getShareAccess(any(), any(), (stateid4) any())).thenReturn(nfs4_prot.OPEN4_SHARE_ACCESS_READ);
         when(stateHandler.getClientIdByStateId(any())).thenReturn(client);
         when(session.getClient()).thenReturn(client);
         when(stateHandler.getClientIdByStateId(any())).thenReturn(client);
@@ -90,7 +98,7 @@ public class OperationREADTest {
         FileTracker fileTracker = mock(FileTracker.class);
 
         when(stateHandler.getFileTracker()).thenReturn(fileTracker);
-        when(fileTracker.getShareAccess(any(), any(), any())).thenReturn(nfs4_prot.OPEN4_SHARE_ACCESS_READ);
+        when(fileTracker.getShareAccess(any(), any(), (stateid4) any())).thenReturn(nfs4_prot.OPEN4_SHARE_ACCESS_READ);
         when(stateHandler.getClientIdByStateId(any())).thenReturn(client);
         when(session.getClient()).thenReturn(client);
         when(stateHandler.getClientIdByStateId(any())).thenReturn(client);

--- a/core/src/test/java/org/dcache/nfs/v4/OperationWRITETest.java
+++ b/core/src/test/java/org/dcache/nfs/v4/OperationWRITETest.java
@@ -1,16 +1,9 @@
 package org.dcache.nfs.v4;
 
-import static org.dcache.nfs.v4.NfsTestUtils.execute;
+import static org.dcache.nfs.v4.NfsTestUtils.*;
 import static org.dcache.nfs.v4.NfsTestUtils.generateRpcCall;
-import static org.dcache.nfs.v4.NfsTestUtils.generateStateId;
-import static org.junit.Assert.assertSame;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.net.UnknownHostException;

--- a/core/src/test/java/org/dcache/nfs/v4/OperationWRITETest.java
+++ b/core/src/test/java/org/dcache/nfs/v4/OperationWRITETest.java
@@ -1,9 +1,16 @@
 package org.dcache.nfs.v4;
 
-import static org.dcache.nfs.v4.NfsTestUtils.*;
+import static org.dcache.nfs.v4.NfsTestUtils.execute;
 import static org.dcache.nfs.v4.NfsTestUtils.generateRpcCall;
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.dcache.nfs.v4.NfsTestUtils.generateStateId;
+import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
@@ -57,14 +64,14 @@ public class OperationWRITETest {
         FileTracker fileTracker = mock(FileTracker.class);
 
         when(stateHandler.getFileTracker()).thenReturn(fileTracker);
-        when(fileTracker.getShareAccess(any(), any(), any())).thenReturn(nfs4_prot.OPEN4_SHARE_ACCESS_WRITE);
+        when(fileTracker.getShareAccess(any(), any(), (stateid4) any())).thenReturn(nfs4_prot.OPEN4_SHARE_ACCESS_WRITE);
         when(stateHandler.getClientIdByStateId(any())).thenReturn(client);
         when(session.getClient()).thenReturn(client);
         when(stateHandler.getClientIdByStateId(any())).thenReturn(client);
 
         when(vfs.getattr(any())).thenReturn(fileStat);
         when(vfs.getattr(any(), any())).thenCallRealMethod();
-        when(vfs.write(any(), any(), anyLong(), any()))
+        when(vfs.write(any(), any(), any(), anyLong(), any()))
                 .thenReturn(new VirtualFileSystem.WriteResult(VirtualFileSystem.StabilityLevel.UNSTABLE, 1));
 
         COMPOUND4args writeArgs = new CompoundBuilder()
@@ -94,14 +101,14 @@ public class OperationWRITETest {
         FileTracker fileTracker = mock(FileTracker.class);
 
         when(stateHandler.getFileTracker()).thenReturn(fileTracker);
-        when(fileTracker.getShareAccess(any(), any(), any())).thenReturn(nfs4_prot.OPEN4_SHARE_ACCESS_WRITE);
+        when(fileTracker.getShareAccess(any(), any(), (stateid4) any())).thenReturn(nfs4_prot.OPEN4_SHARE_ACCESS_WRITE);
         when(stateHandler.getClientIdByStateId(any())).thenReturn(client);
         when(session.getClient()).thenReturn(client);
         when(stateHandler.getClientIdByStateId(any())).thenReturn(client);
 
         when(vfs.getattr(any())).thenReturn(fileStat);
         when(vfs.getattr(any(), any())).thenCallRealMethod();
-        when(vfs.write(any(), any(), anyLong(), any()))
+        when(vfs.write(any(), any(), any(), anyLong(), any()))
                 .thenReturn(new VirtualFileSystem.WriteResult(VirtualFileSystem.StabilityLevel.UNSTABLE, 1));
 
         COMPOUND4args writeArgs = new CompoundBuilder()
@@ -131,7 +138,7 @@ public class OperationWRITETest {
         FileTracker fileTracker = mock(FileTracker.class);
 
         when(stateHandler.getFileTracker()).thenReturn(fileTracker);
-        when(fileTracker.getShareAccess(any(), any(), any())).thenReturn(nfs4_prot.OPEN4_SHARE_ACCESS_WRITE);
+        when(fileTracker.getShareAccess(any(), any(), (stateid4) any())).thenReturn(nfs4_prot.OPEN4_SHARE_ACCESS_WRITE);
         when(stateHandler.getClientIdByStateId(any())).thenReturn(client);
         when(session.getClient()).thenReturn(client);
         when(stateHandler.getClientIdByStateId(any())).thenReturn(client);
@@ -140,7 +147,7 @@ public class OperationWRITETest {
 
         when(vfs.getattr(any())).thenReturn(fileStat);
         when(vfs.getattr(any(), any())).thenCallRealMethod();
-        when(vfs.write(any(), any(), anyLong(), any()))
+        when(vfs.write(any(), any(), any(), anyLong(), any()))
                 .thenReturn(new VirtualFileSystem.WriteResult(VirtualFileSystem.StabilityLevel.UNSTABLE, 1));
 
         COMPOUND4args writeArgs = new CompoundBuilder()

--- a/core/src/test/java/org/dcache/nfs/v4/xdr/stateid4Test.java
+++ b/core/src/test/java/org/dcache/nfs/v4/xdr/stateid4Test.java
@@ -19,10 +19,9 @@
  */
 package org.dcache.nfs.v4.xdr;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import org.dcache.nfs.v4.xdr.stateid4;
-import org.dcache.nfs.v4.xdr.uint32_t;
 import org.junit.Test;
 
 public class stateid4Test {
@@ -30,13 +29,9 @@ public class stateid4Test {
     @Test
     public void testEqualsTrue() {
 
-        stateid4 stateidA = new stateid4();
-        stateidA.seqid = 1;
-        stateidA.other = "state".getBytes();
+        stateid4 stateidA = stateid4.forBytes("state".getBytes(), 1);
 
-        stateid4 stateidB = new stateid4();
-        stateidB.seqid = 1;
-        stateidB.other = "state".getBytes();
+        stateid4 stateidB = stateid4.forBytes("state".getBytes(), 1);
 
         assertTrue("equal keys not equal", stateidA.equals(stateidB));
         assertTrue("equal, but different hashCode", stateidA.hashCode() == stateidB.hashCode());
@@ -46,9 +41,7 @@ public class stateid4Test {
     @Test
     public void testEqualsSame() {
 
-        stateid4 stateidA = new stateid4();
-        stateidA.seqid = 1;
-        stateidA.other = "state".getBytes();
+        stateid4 stateidA = stateid4.forBytes("state".getBytes(), 1);
 
         assertTrue("equal keys not equal", stateidA.equals(stateidA));
     }
@@ -56,13 +49,9 @@ public class stateid4Test {
     @Test
     public void testDifferSequence() {
 
-        stateid4 stateidA = new stateid4();
-        stateidA.seqid = 1;
-        stateidA.other = "state".getBytes();
+        stateid4 stateidA = stateid4.forBytes("state".getBytes(), 1);
 
-        stateid4 stateidB = new stateid4();
-        stateidB.seqid = 2;
-        stateidB.other = "state".getBytes();
+        stateid4 stateidB = stateid4.forBytes("state".getBytes(), 2);
 
         assertTrue("differ by sequence should still be equal", stateidA.equals(stateidB));
         assertFalse("differ by sequence can't be equal", stateidA.equalsWithSeq(stateidB));
@@ -71,13 +60,9 @@ public class stateid4Test {
     @Test
     public void testDifferOther() {
 
-        stateid4 stateidA = new stateid4();
-        stateidA.seqid = 1;
-        stateidA.other = "stateA".getBytes();
+        stateid4 stateidA = stateid4.forBytes("stateA".getBytes(), 1);
 
-        stateid4 stateidB = new stateid4();
-        stateidB.seqid = 1;
-        stateidB.other = "stateB".getBytes();
+        stateid4 stateidB = stateid4.forBytes("stateB".getBytes(), 1);
 
         assertFalse("differ by other not detected", stateidA.equals(stateidB));
     }

--- a/core/src/test/java/org/dcache/nfs/v4/xdr/stateid4Test.java
+++ b/core/src/test/java/org/dcache/nfs/v4/xdr/stateid4Test.java
@@ -29,9 +29,9 @@ public class stateid4Test {
     @Test
     public void testEqualsTrue() {
 
-        stateid4 stateidA = stateid4.forBytes("state".getBytes(), 1);
+        stateid4 stateidA = new stateid4("state".getBytes(), 1);
 
-        stateid4 stateidB = stateid4.forBytes("state".getBytes(), 1);
+        stateid4 stateidB = new stateid4("state".getBytes(), 1);
 
         assertTrue("equal keys not equal", stateidA.equals(stateidB));
         assertTrue("equal, but different hashCode", stateidA.hashCode() == stateidB.hashCode());
@@ -41,7 +41,7 @@ public class stateid4Test {
     @Test
     public void testEqualsSame() {
 
-        stateid4 stateidA = stateid4.forBytes("state".getBytes(), 1);
+        stateid4 stateidA = new stateid4("state".getBytes(), 1);
 
         assertTrue("equal keys not equal", stateidA.equals(stateidA));
     }
@@ -49,9 +49,9 @@ public class stateid4Test {
     @Test
     public void testDifferSequence() {
 
-        stateid4 stateidA = stateid4.forBytes("state".getBytes(), 1);
+        stateid4 stateidA = new stateid4("state".getBytes(), 1);
 
-        stateid4 stateidB = stateid4.forBytes("state".getBytes(), 2);
+        stateid4 stateidB = new stateid4("state".getBytes(), 2);
 
         assertTrue("differ by sequence should still be equal", stateidA.equals(stateidB));
         assertFalse("differ by sequence can't be equal", stateidA.equalsWithSeq(stateidB));
@@ -60,9 +60,9 @@ public class stateid4Test {
     @Test
     public void testDifferOther() {
 
-        stateid4 stateidA = stateid4.forBytes("stateA".getBytes(), 1);
+        stateid4 stateidA = new stateid4("stateA".getBytes(), 1);
 
-        stateid4 stateidB = stateid4.forBytes("stateB".getBytes(), 1);
+        stateid4 stateidB = new stateid4("stateB".getBytes(), 1);
 
         assertFalse("differ by other not detected", stateidA.equals(stateidB));
     }

--- a/core/src/test/java/org/dcache/nfs/v4/xdr/stateid4Test.java
+++ b/core/src/test/java/org/dcache/nfs/v4/xdr/stateid4Test.java
@@ -19,8 +19,7 @@
  */
 package org.dcache.nfs.v4.xdr;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import org.junit.Test;
 


### PR DESCRIPTION
Currently, read and write operations to the VirtualFileSystem are "stateless" in the sense that there is no corresponding "open" and "close" exposed. At the NFS4 level, this exists, and nfs4j tracks these internally already (`stateid4.opaque` byte sequences), but they're not exposed to `VirtualFileSystem`.

This is a problem not only for scenarios where an explicit open/close is required, but even for currently implemented scenarios it's a performance problem: PseudoFs calls `checkAccess(inode, ACE4_READ_DATA/ACE4_WRITE_DATA)` for each `read`/`write`, which in turn triggers a Stat for each read/write operation.

This incurs an unnecessary performance penalty of more than 20%.

The access check is unnecessary because a successful check upon "open" will be valid for the entire lifetime of the call, just as it is when opening a file descriptor in POSIX.

In order to properly track granted access, we can leverage data stored in stateid4 and the existing work in FileTracker.

Since stateid4 exists in NFSv4 only, we make sure there is no performance degradation in NFSv3 and no exposure of NFSv4-only internals in the VirtualFileSystem API:

1. Expose "Opaque" stateids to VirtualFileSystem read/write/commit; add open/close for custom FS interop.
2. Rework stateid4, which currently conflates stateid and seqid -- directly reference stateid4.other Opaque when possible.
3. In PseudoFS, check SharedAccess state from FileTracker and use this to determine access during read/write when available.

With the change, for sustained reads I'm seeing 854 MB/s instead of 712 MB/s on LocalFileSystem, and 2000 MB/s instead of 1666 MB/s on a custom implementation.
