### PR TITLE
core: Improve access tracking performance for read/write

### DIFF
--- a/core/src/main/java/org/dcache/nfs/v4/NFSServerV41.java
+++ b/core/src/main/java/org/dcache/nfs/v4/NFSServerV41.java
@@ -134,7 +134,7 @@ public class NFSServerV41 extends nfs4_prot_NFS4_PROGRAM_ServerStub {
             }
             res.resarray = new ArrayList<>(arg1.argarray.length);
 
-            VirtualFileSystem fs = new PseudoFs(_fs, call$, _exportTable);
+            VirtualFileSystem fs = new PseudoFs(_fs, call$, _exportTable, _statHandler);
 
             CompoundContextBuilder builder = new CompoundContextBuilder()
                     .withMinorversion(arg1.minorversion.value)

--- a/core/src/main/java/org/dcache/nfs/v4/NFSv4StateHandler.java
+++ b/core/src/main/java/org/dcache/nfs/v4/NFSv4StateHandler.java
@@ -237,13 +237,22 @@ public class NFSv4StateHandler {
         }
     }
 
+    public NFS4Client getClientIfExists(long clientId) {
+        _readLock.lock();
+        try {
+            return _clientsByServerId.get(new clientid4(clientId));
+        } finally {
+            _readLock.unlock();
+        }
+    }
+
     public NFS4Client getClientIdByStateId(stateid4 stateId) throws ChimeraNFSException {
 
         _readLock.lock();
         try {
             checkState(_running, "NFS state handler not running");
 
-            clientid4 clientId = new clientid4(Bytes.getLong(stateId.other, 0));
+            clientid4 clientId = new clientid4(stateId.getClientId());
             NFS4Client client = _clientsByServerId.get(clientId);
             if (client == null) {
                 throw new BadStateidException("no client for stateid: " + stateId);

--- a/core/src/main/java/org/dcache/nfs/v4/OperationREAD.java
+++ b/core/src/main/java/org/dcache/nfs/v4/OperationREAD.java
@@ -73,7 +73,7 @@ public class OperationREAD extends AbstractNFSv4Operation {
         ByteBuffer buf = ByteBuffer.allocate(count);
 
         res.resok4 = new READ4resok();
-        int bytesRead = context.getFs().read(inode, buf, offset, res.resok4::setEOF);
+        int bytesRead = context.getFs().read(stateid, inode, buf, offset, res.resok4::setEOF);
 
         if (bytesRead < 0) {
             buf.clear();

--- a/core/src/main/java/org/dcache/nfs/v4/OperationWRITE.java
+++ b/core/src/main/java/org/dcache/nfs/v4/OperationWRITE.java
@@ -87,7 +87,7 @@ public class OperationWRITE extends AbstractNFSv4Operation {
         }
 
         long offset = _args.opwrite.offset.value;
-        VirtualFileSystem.WriteResult writeResult = context.getFs().write(context.currentInode(),
+        VirtualFileSystem.WriteResult writeResult = context.getFs().write(stateid, context.currentInode(),
                 _args.opwrite.data, offset, VirtualFileSystem.StabilityLevel.fromStableHow(_args.opwrite.stable));
 
         if (writeResult.getBytesWritten() < 0) {

--- a/core/src/main/java/org/dcache/nfs/v4/xdr/stateid4.java
+++ b/core/src/main/java/org/dcache/nfs/v4/xdr/stateid4.java
@@ -23,14 +23,17 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
 
+import org.dcache.nfs.util.Opaque;
+import org.dcache.nfs.vfs.OpenHandle;
 import org.dcache.oncrpc4j.rpc.OncRpcException;
+import org.dcache.oncrpc4j.util.Bytes;
 import org.dcache.oncrpc4j.xdr.XdrAble;
 import org.dcache.oncrpc4j.xdr.XdrDecodingStream;
 import org.dcache.oncrpc4j.xdr.XdrEncodingStream;
 
 import com.google.common.io.BaseEncoding;
 
-public class stateid4 implements XdrAble, Serializable {
+public class stateid4 implements XdrAble, Serializable, OpenHandle {
 
     static final long serialVersionUID = -6677150504723505919L;
 
@@ -93,6 +96,15 @@ public class stateid4 implements XdrAble, Serializable {
     @Override
     public int hashCode() {
         return Arrays.hashCode(other);
+    }
+
+    public long getClientId() {
+        return Bytes.getLong(other, 0);
+    }
+
+    @Override
+    public Opaque getOpaque() {
+        return Opaque.forMutableByteArray(other);
     }
 
     @Override

--- a/core/src/main/java/org/dcache/nfs/vfs/ForwardingFileSystem.java
+++ b/core/src/main/java/org/dcache/nfs/vfs/ForwardingFileSystem.java
@@ -107,8 +107,8 @@ public abstract class ForwardingFileSystem implements VirtualFileSystem {
     }
 
     @Override
-    public int read(Inode inode, ByteBuffer data, long offset, Runnable eofReached) throws IOException {
-        return delegate().read(inode, data, offset, eofReached);
+    public int read(OpenHandle oh, Inode inode, ByteBuffer data, long offset, Runnable eofReached) throws IOException {
+        return delegate().read(oh, inode, data, offset, eofReached);
     }
 
     @Override
@@ -136,6 +136,12 @@ public abstract class ForwardingFileSystem implements VirtualFileSystem {
     public WriteResult write(Inode inode, ByteBuffer data, long offset, StabilityLevel stabilityLevel)
             throws IOException {
         return delegate().write(inode, data, offset, stabilityLevel);
+    }
+
+    @Override
+    public WriteResult write(OpenHandle oh, Inode inode, ByteBuffer data, long offset, StabilityLevel stabilityLevel)
+            throws IOException {
+        return delegate().write(oh, inode, data, offset, stabilityLevel);
     }
 
     @Override

--- a/core/src/main/java/org/dcache/nfs/vfs/OpenHandle.java
+++ b/core/src/main/java/org/dcache/nfs/vfs/OpenHandle.java
@@ -1,0 +1,20 @@
+package org.dcache.nfs.vfs;
+
+import org.dcache.nfs.util.Opaque;
+
+/**
+ * Describes metadata determined upon opening the resource at the NFS level.
+ * <p>
+ * This is used, for example, to infer access privileges that were determined upon opening a resource, so read/write
+ * operations don't have to check every time.
+ * 
+ * @see PseudoFs
+ */
+public interface OpenHandle {
+    /**
+     * Returns an opaque bytes representation of the handle.
+     * 
+     * @return The opaque.
+     */
+    Opaque getOpaque();
+}

--- a/core/src/main/java/org/dcache/nfs/vfs/VirtualFileSystem.java
+++ b/core/src/main/java/org/dcache/nfs/vfs/VirtualFileSystem.java
@@ -226,6 +226,7 @@ public interface VirtualFileSystem {
      * information via {@link #getattr(Inode)}), which may incur a higher, recurring cost than the inconvenience of a
      * single additional client roundtrip at the end of the file.
      *
+     * @param oh The open-handle, or {@code null}.
      * @param inode inode of the file to read from.
      * @param data byte array for writing.
      * @param offset file's position to read from.
@@ -234,7 +235,7 @@ public interface VirtualFileSystem {
      * @return number of bytes read from the file, possibly zero. -1 if EOF is reached.
      * @throws IOException
      */
-    default int read(Inode inode, ByteBuffer data, long offset, Runnable eofReached) throws IOException {
+    default int read(OpenHandle oh, Inode inode, ByteBuffer data, long offset, Runnable eofReached) throws IOException {
         Stat stat = getattr(inode);
 
         Stat.Type statType = stat.type();
@@ -302,6 +303,7 @@ public interface VirtualFileSystem {
     /**
      * Write provided {@code data} into inode with a given stability level.
      *
+     * @param oh The open-handle, or {@code null}.
      * @param inode inode of the file to write.
      * @param data data to be written.
      * @param offset the file position to begin writing at.
@@ -315,6 +317,22 @@ public interface VirtualFileSystem {
         byte[] bytes = new byte[count];
         data.get(bytes);
         return write(inode, bytes, offset, count, stabilityLevel);
+    }
+
+    /**
+     * Write provided {@code data} into inode with a given stability level.
+     *
+     * @param oh Carries metadata determined upon opening the resource at the NFS level, or {@code null}.
+     * @param inode inode of the file to write.
+     * @param data data to be written.
+     * @param offset the file position to begin writing at.
+     * @param stabilityLevel data stability level.
+     * @return write result.
+     * @throws IOException
+     */
+    default WriteResult write(OpenHandle oh, Inode inode, ByteBuffer data, long offset, StabilityLevel stabilityLevel)
+            throws IOException {
+        return write(inode, data, offset, stabilityLevel);
     }
 
     /**

--- a/core/src/test/java/org/dcache/nfs/v4/OperationWRITETest.java
+++ b/core/src/test/java/org/dcache/nfs/v4/OperationWRITETest.java
@@ -64,7 +64,7 @@ public class OperationWRITETest {
 
         when(vfs.getattr(any())).thenReturn(fileStat);
         when(vfs.getattr(any(), any())).thenCallRealMethod();
-        when(vfs.write(any(), any(), anyLong(), any()))
+        when(vfs.write(any(), any(), any(), anyLong(), any()))
                 .thenReturn(new VirtualFileSystem.WriteResult(VirtualFileSystem.StabilityLevel.UNSTABLE, 1));
 
         COMPOUND4args writeArgs = new CompoundBuilder()
@@ -101,7 +101,7 @@ public class OperationWRITETest {
 
         when(vfs.getattr(any())).thenReturn(fileStat);
         when(vfs.getattr(any(), any())).thenCallRealMethod();
-        when(vfs.write(any(), any(), anyLong(), any()))
+        when(vfs.write(any(), any(), any(), anyLong(), any()))
                 .thenReturn(new VirtualFileSystem.WriteResult(VirtualFileSystem.StabilityLevel.UNSTABLE, 1));
 
         COMPOUND4args writeArgs = new CompoundBuilder()
@@ -140,7 +140,7 @@ public class OperationWRITETest {
 
         when(vfs.getattr(any())).thenReturn(fileStat);
         when(vfs.getattr(any(), any())).thenCallRealMethod();
-        when(vfs.write(any(), any(), anyLong(), any()))
+        when(vfs.write(any(), any(), any(), anyLong(), any()))
                 .thenReturn(new VirtualFileSystem.WriteResult(VirtualFileSystem.StabilityLevel.UNSTABLE, 1));
 
         COMPOUND4args writeArgs = new CompoundBuilder()


### PR DESCRIPTION
Currently, read and write operations to the VirtualFileSystem are
"stateless" in the sense that there is no corresponding "open" and
"close" exposed. At the NFS4 level, this exists, and nfs4j tracks these
internally already (stateid4.opaque byte sequences), but they're not
exposed to VirtualFileSystem.
    
This is a performance problem: PseudoFs calls checkAccess(inode,
ACE4_READ_DATA/ACE4_WRITE_DATA) for each read/write, which in turn
triggers a Stat for each read/write operation.
    
This incurs an unnecessary performance penalty of more than 20%.
   
The access check is unnecessary because a successful check upon "open"
will be valid for the entire lifetime of the client-side file
descriptor, just as it is when opening a file descriptor on other POSIX
file systems.
    
In order to properly track granted access, we can leverage data stored
in stateid4 and the existing work in FileTracker.
    
Since stateid4 exists in NFSv4 only, we make sure there is no
performance degradation in NFSv3 and no exposure of NFSv4-only internals
in the VirtualFileSystem API:
    
Expose stateids as OpenHandle to VirtualFileSystem read/write,
defaulting to existing read/write methods for backwards compatibility.
In PseudoFS, check SharedAccess state from FileTracker and use this to
determine access during read/write when available. Rework stateid4 to
implement OpenHandle, and expose ClientId (the first 8 bytes of the
opaque) so we can look up the information in NFSv4StateHandler.
    
With the change, for sustained reads I'm seeing 854 MB/s instead of 712
MB/s on LocalFileSystem, and 2000 MB/s instead of 1666 MB/s on a custom
implementation.
