### PR TITLE
nfs4: apply time_create as birth time in SETATTR

### DIFF
--- a/basic-server/src/main/java/org/dcache/nfs4j/server/LocalFileSystem.java
+++ b/basic-server/src/main/java/org/dcache/nfs4j/server/LocalFileSystem.java
@@ -584,7 +584,7 @@ public class LocalFileSystem implements VirtualFileSystem {
         }
         if (stat.isDefined(Stat.StatAttribute.ATIME)) {
             try {
-                FileTime time = FileTime.fromMillis(stat.getCTime());
+                FileTime time = FileTime.fromMillis(stat.getATime());
                 Files.setAttribute(path, "unix:lastAccessTime", time, NOFOLLOW_LINKS);
             } catch (IOException e) {
                 throw new UnsupportedOperationException("set atime failed: " + e.getMessage(), e);
@@ -598,12 +598,12 @@ public class LocalFileSystem implements VirtualFileSystem {
                 throw new UnsupportedOperationException("set mtime failed: " + e.getMessage(), e);
             }
         }
-        if (stat.isDefined(Stat.StatAttribute.CTIME)) {
+        if (stat.isDefined(Stat.StatAttribute.BTIME)) {
             try {
-                FileTime time = FileTime.fromMillis(stat.getCTime());
-                Files.setAttribute(path, "unix:ctime", time, NOFOLLOW_LINKS);
+                FileTime time = FileTime.fromMillis(stat.getBTime());
+                Files.setAttribute(path, "basic:creationTime", time, NOFOLLOW_LINKS);
             } catch (IOException e) {
-                throw new UnsupportedOperationException("set ctime failed: " + e.getMessage(), e);
+                throw new UnsupportedOperationException("set btime failed: " + e.getMessage(), e);
             }
         }
     }

--- a/core/src/main/java/org/dcache/nfs/v4/OperationSETATTR.java
+++ b/core/src/main/java/org/dcache/nfs/v4/OperationSETATTR.java
@@ -185,9 +185,9 @@ public class OperationSETATTR extends AbstractNFSv4Operation {
                 stat.setATime(realAtime);
                 break;
             case nfs4_prot.FATTR4_TIME_CREATE:
-                nfstime4 ctime = new nfstime4();
-                ctime.xdrDecode(xdr);
-                stat.setCTime(ctime.toMillis());
+                nfstime4 btime = new nfstime4();
+                btime.xdrDecode(xdr);
+                stat.setBTime(btime.toMillis());
                 break;
             case nfs4_prot.FATTR4_TIME_MODIFY_SET:
                 settime4 setMtime = new settime4();


### PR DESCRIPTION
Motivation:
The macOS NFS client sends a SETATTR with time_create after an exclusive create. OperationSETATTR maps FATTR4_TIME_CREATE to Stat.CTIME, although rfc7530/rfc8881 define time_create as the creation (birth) time, explicitly unrelated to the POSIX change time, and OperationGETATTR already serves time_create from Stat.BTIME. LocalFileSystem then tries to set the non-settable "unix:ctime" attribute, which throws IllegalArgumentException and turns the compound into NFS4ERR_SERVERFAULT. macOS maps SERVERFAULT to EBADRPC, so open(O_CREAT|O_EXCL) fails with errno 72 while the file is created on the server.

Modification:
map FATTR4_TIME_CREATE to Stat.BTIME in OperationSETATTR, matching the GETATTR side. In LocalFileSystem apply BTIME via "basic:creationTime", drop the "unix:ctime" branch, and fix the ATIME branch that used getCTime().

Result:
exclusive create from macOS clients works over NFS 4.0 and 4.1.

Fixes: #174
Target: master